### PR TITLE
feat: permitir que admin pueda editar la contrasenna sin pedir la anterior

### DIFF
--- a/API/models/user.js
+++ b/API/models/user.js
@@ -76,23 +76,27 @@ module.exports = (sequelize, DataTypes) => {
     return await generateToken(this);
   }
 
-  user.prototype.handlePasswordChange = async function (oldPassword, newPassword) {
-    if (!newPassword || !oldPassword) {
+  user.prototype.handlePasswordChange = async function (oldPassword, newPassword ) {
+    if (!newPassword) {
       throw new ErrorHandler(passwordIsRequired);
     }
 
-    const doesPasswordMatch = await this.checkPassword(oldPassword);
-    if (!doesPasswordMatch) {
-      throw new ErrorHandler(passwordsDontMatch);
+    if (oldPassword) {
+      // Actualmente no se mandará la contraseña actual para actualizarla con una nueva,
+      // pero se deja la lógica por si se decide implementar en un futuro
+      const doesPasswordMatch = await this.checkPassword(oldPassword);
+      if (!doesPasswordMatch) {
+        throw new ErrorHandler(passwordsDontMatch);
+      }
+
+      if (oldPassword === newPassword) {
+        throw new ErrorHandler(newPasswordCantBeTheSame);
+      }
     }
 
     const isPasswordValid = await this.checkPasswordValidation(newPassword);
     if (!isPasswordValid) {
       throw new ErrorHandler(badPasswordValidation);
-    }
-
-    if (oldPassword === newPassword) {
-      throw new ErrorHandler(newPasswordCantBeTheSame);
     }
 
     await this.updatePassword(newPassword);

--- a/API/src/controllers/client.controller.js
+++ b/API/src/controllers/client.controller.js
@@ -64,19 +64,22 @@ const editClient = async (req, res, next) => {
     }
 
     if (requesterRole === 'admin'){
-      //TODO check some kind of password or passphrase confirmation 
+      //TODO check some kind of password or passphrase confirmation
+      const password = req.body.encrypted_password;
+
+      // Quitamos el password del body para actualizar los datos del cliente por separado
+      if (password) {
+        delete req.body.encrypted_password;
+        await user.handlePasswordChange(undefined, password);
+      }
+
       await client.updateDetails(user, person, req.body);
       return res.json({ message: `Cliente ${client.id} editado exitosamente.` });
     }
     
-    if (requesterRole === 'normal' & client.userId !== requesterId) {
+    if (requesterRole === 'normal') {
       throw new ErrorHandler(unauthorized);
     }
-
-    const { newPassword, oldPassword } = req.body;
-    await user.handlePasswordChange(oldPassword, newPassword)
-
-    return res.json({ message: `Contraseña del cliente ${client.id} fue editada exitosamente.` });
   } catch (error) {
     next(error);
   }

--- a/API/src/routes/client.route.js
+++ b/API/src/routes/client.route.js
@@ -25,6 +25,6 @@ router.post('/clients/:id/wells/create', authMiddleware('normal', 'admin'), vali
 router.post('/clients/:id/wells/:code/add', authMiddleware('normal', 'admin'), validateParams(addDataToWell), addDataToClientWell);
 router.delete('/clients/:id/delete', authMiddleware('normal', 'admin'), deleteClient);
 router.delete('/clients/:id/wells/:code/delete', authMiddleware('normal', 'admin'), deleteClientWell);
-router.put('/clients/:id/wells/:code/edit', authMiddleware('normal', 'admin'), validateParams(editDataOfWell), editClientWell);
+router.put('/clients/:id/wells/:code/edit', authMiddleware('admin'), validateParams(editDataOfWell), editClientWell);
 
 module.exports = router;


### PR DESCRIPTION
## Issues relacionados

[tarjeta](https://trello.com/c/C7AOojQ5)

## Descripción del problema (en caso de que no exista un issue que lo explique)

No estaba implementado la edición de la contraseña desde el front, pero en el back estaba implementado que el usuario normal pudiera editar su contraseña, requiriendo la actual (para confirmar que eres tu el que quiere editarla).

Por requerimientos de negocios, esta lógica cambió. Se necesita que el admin sea el único que pueda editar todo, incluida la contraseña, y sin pedir la anterior. Esto dado que el admin puede olvidar la primera contraseña que creó, entonces simplemente le setea una nueva al usuario.

## Solución propuesta

Se impide que el usuario normal pueda editar su contraseña y, además, se incluye el manejo de lóogica para editar la contraseña de forma independiente al resto de los campos de edición de usuario.

También en el modelo `user`, se deja como opcional el parámetro de `oldPassword` por si en un futuro si se quiera que los usuarios normales editen su contraseña.

## Screenshots

n/a

## Cómo probar

- correr `npm install` (salió una nueva versión de npm asi que te reocmendará que lo instales)
- iniciar el servidor con `npm run dev`
- desde postman, editar la contraseña de un usuario, el campo tiene el nombre de `encrypted_password`
- también (y recomendable) probar su funcionalidad integral con el servidor de front levantado, desde la misma app