### PR TITLE
Feature/implementar envio con after create well data

### DIFF
--- a/API/models/welldata.js
+++ b/API/models/welldata.js
@@ -2,6 +2,8 @@
 const {
   Model
 } = require('sequelize');
+const handleData = require('../src/services/wellData/handleSendData.service');
+const moment = require('moment-timezone');
 module.exports = (sequelize, DataTypes) => {
   class wellData extends Model {
     /**
@@ -54,7 +56,12 @@ module.exports = (sequelize, DataTypes) => {
 
     hooks: {
       afterCreate: async (wellData) => {
-        //todo
+        try {
+          await handleData(wellData);
+          wellData.update({ sent: true, sentDate: new moment().tz('America/Santiago').format() })
+        } catch (error) {
+          console.log(error);
+        }
       }
     },
     sequelize,

--- a/API/src/utils/errorcodes.util.js
+++ b/API/src/utils/errorcodes.util.js
@@ -71,6 +71,11 @@ const newPasswordCantBeTheSame = {
   message: 'La nueva contraseña no puede ser igual a la anterior',
 }
 
+const wellDataHasInvalidData = {
+  code: 400,
+  message: 'Los datos del pozo son inválidos',
+}
+
 module.exports = {
   userNotFound,
   missingParams,
@@ -85,5 +90,6 @@ module.exports = {
   trol,
   badPasswordValidation,
   newPasswordCantBeTheSame,
-  wellHasDataAssociated
+  wellHasDataAssociated,
+  wellDataHasInvalidData
 }


### PR DESCRIPTION
## Issues relacionados

[tarjeta](https://trello.com/c/k5q4Nc5G)

## Descripción del problema (en caso de que no exista un issue que lo explique)

Necesitabamos implementar que, al recibir un reporte, inmediatamente se intentara enviar a la dga. Mas adelante se implementará el caso de que no funcione el envio.

## Solución propuesta

Se agrega un `afterCreate` en el modelo `wellData` para llamar a la función que envía los reportes.

## Screenshots

Pantallazos o gift de los cambios si es que son visuales en la aplicación

## Cómo probar

- Levantar servidor con `node server.js` para revisar que funcione en local
- Levantar docker para comprobar que funciona correctamente