### PR TITLE
chore: crear nueva columna de createdBy en modelo user

### DIFF
--- a/API/migrations/20240718034030-add-new-column-to-user-created-by.js
+++ b/API/migrations/20240718034030-add-new-column-to-user-created-by.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn(
+      'users',
+      'createdBy',
+      {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        unique: false
+      }
+    );
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('users', 'createdBy');
+  }
+};


### PR DESCRIPTION
## Issues relacionados

[tarjeta](https://trello.com/c/yJLlINAu)

## Descripción del problema (en caso de que no exista un issue que lo explique)

necesitabamos tener una forma de saber quien crea un usuario, de tal forma que podamos enlazar la idea de tener cada empresa independiente con sus propios clientes

## Solución propuesta

se añade una migración con la columna `createdBy` en el modelo `user`, será `INT` y contendrá los id's de otros user (creadores) 

## Screenshots

n/a

## Cómo probar

- moverse a esta rama
- correr las migraciones con `npx sequelize-cli db:migrate`