### PR TITLE
Feature: Terminar flujo de empresa para permitir crear, ver, editar y eliminar clientes y pozos.

### DIFF
--- a/API/src/controllers/user.controller.js
+++ b/API/src/controllers/user.controller.js
@@ -130,7 +130,7 @@ const registerUser = async (req, res, next) => {
     if (!checkPermissionsForClientResources(req.user, undefined, true)) {
       throw new ErrorHandler(unauthorized);
     }
-
+    
     const userParams = {
       name: req.body.name,
       email: req.body.email,
@@ -152,9 +152,14 @@ const registerUser = async (req, res, next) => {
     });
 
     if (role.type === "normal") {
-      await Client.create({ userId: user.id }, { transaction });
-    }
+      const clientParams = { userId: user.id };
+      if (req.body.companyId) {
+        clientParams.companyId = parseInt(req.body.companyId, 10);
+      }
 
+      await Client.create(clientParams, { transaction });
+    }
+    
     let personalParams = {};
     if (role.type === "normal" || role.type === "admin") {
       personalParams = {

--- a/API/src/routes/user.route.js
+++ b/API/src/routes/user.route.js
@@ -25,6 +25,6 @@ router.get('/users/data/:id', authMiddleware(...AllRoles), getUserInfoById);
 router.post('/users/register',  authMiddleware(...AdminAndCompany), validateParams(registerParams, true), registerUser);
 router.post('/users/login', validateParams(loginParams), loginUser);
 router.get('/users/role/:id', authMiddleware(...AllRoles), getUserRoleById);
-router.get('/users/roles', authMiddleware(...Admin), getAllUserRoles);
+router.get('/users/roles', authMiddleware(...AdminAndCompany), getAllUserRoles);
 
 module.exports = router;

--- a/API/src/utils/check-permissions.js
+++ b/API/src/utils/check-permissions.js
@@ -1,15 +1,21 @@
+const db = require('../../models');
+const Company = db.company;
+
 // Funcion que permite a un admin acceder a cualquier recurso
 // a un company acceder a los recursos que el mismo creo
 // y a un normal acceder a los recursos que le pertenecen || OJO con esto deberia solo servir para algunos casos, como getUserInfoById
-const checkPermissionsForClientResources = (user, entity, beingModified = false) => {
+const checkPermissionsForClientResources = async (user, entity)=> {
     const { id: requesterId, type: requesterRole } = user;
 
     if (requesterRole === 'admin') {
         return true;
     }
 
-    if (requesterRole === 'company' && (beingModified || entity?.createdBy === requesterId || entity?.companyId === requesterId)) {
-        return true;
+    if (requesterRole === 'company'){
+        const company = await Company.findOne({ where: {userId: requesterId} })
+        if (entity?.createdBy === requesterId || entity?.companyId === company.id) {
+            return true;
+        }
     }
 
     if (requesterRole === 'normal' && entity?.userId === requesterId) {


### PR DESCRIPTION
## Issues relacionados

n/a

## Descripción del problema (en caso de que no exista un issue que lo explique)

El flujo de empresa no estaba terminado, faltaba darle los permisos para crear, editar y visualizar los clientes asociados a la misma empresa.

## Solución propuesta

Se añaden los permisos en rutas y en el `checkParams` para verificar que una empresa solo pueda ver/editar clientes asociados a ella.

## Screenshots

n/a

## Cómo probar

- Levantar servidor con `node server.js` para revisar que funcione en local
- Levantar docker para comprobar que funciona correctamente