### PR TITLE
fix(p0): estabilizar API ante crashes y timeouts en producción

### DIFF
--- a/API/models/welldata.js
+++ b/API/models/welldata.js
@@ -62,17 +62,29 @@ module.exports = (sequelize, DataTypes) => {
     },
     {
       hooks: {
-        afterCreate: async (wellData) => {
-          try {
-            // Sólo se pueden enviar reportes de pozos activos
-            const well = await wellData.getWell();
-
-            if (well.isActived) {
-              await processAndPostData(wellData, well);
+        // Fire-and-forget: NO retornamos la promesa al hook, así Sequelize
+        // no espera al envío a DGA antes de resolver `WellData.create()`.
+        // Si DGA falla o tarda, el reporte queda con `sent: false` y el
+        // SENDER lo reintenta en su próxima corrida. Esto desacopla el
+        // SLA del endpoint POST /wellData del SLA de la DGA y evita los
+        // timeouts del lado del cliente IoT (Layrz) que vimos en prod.
+        afterCreate: (wellData) => {
+          setImmediate(async () => {
+            try {
+              const well = await wellData.getWell();
+              if (well?.isActived) {
+                await processAndPostData(wellData, well);
+              }
+            } catch (error) {
+              console.error(JSON.stringify({
+                level: 'error',
+                msg: 'DGA dispatch failed in afterCreate hook',
+                wellDataId: wellData.id,
+                code: wellData.code,
+                error: error.message,
+              }));
             }
-          } catch (error) {
-            console.log(error);
-          }
+          });
         },
       },
       sequelize,

--- a/API/src/app.js
+++ b/API/src/app.js
@@ -36,6 +36,11 @@ app.use(activityLogRoute);
 // Ruta formulario de contacto
 app.use(contactRoute);
 
+// 404 explícito para cualquier ruta no registrada (debe ir antes del error handler)
+app.use((req, res) => {
+  return res.status(404).json({ error: 'Not found' });
+});
+
 // Middleware de manejo de errores
 app.use(errorHandler);
 

--- a/API/src/controllers/stats.controller.js
+++ b/API/src/controllers/stats.controller.js
@@ -12,7 +12,7 @@ const Op = db.Op;
  * Get global statistics for the admin dashboard
  * Returns total counts and monthly trends for clients, companies, distributors, and wells
  */
-const getGlobalStats = async (req, res) => {
+const getGlobalStats = async (req, res, next) => {
   try {
     // Calculate date range for "this month"
     const now = new Date();
@@ -119,10 +119,7 @@ const getGlobalStats = async (req, res) => {
     });
   } catch (error) {
     console.error("Error fetching global stats:", error);
-    return res.status(500).json({
-      message: "Error al obtener estadísticas globales",
-      error: error.message,
-    });
+    return next(error);
   }
 };
 

--- a/API/src/controllers/well.controller.js
+++ b/API/src/controllers/well.controller.js
@@ -14,48 +14,44 @@ const User = db.user;
 const Person = db.person;
 
 //  TODO: no se esta usando ninguno de estos métodos excepto el activeOrDesactiveWell
-const getAllWells = async (req, res) => {
+const getAllWells = async (req, res, next) => {
   try {
     const wells = await Well.findAll();
-    res.json(wells);
+    return res.json(wells);
   } catch (error) {
-    res.status(500).send({
-      message: error.message || 'Some error occurred while retrieving Wells'
-    });
+    return next(error);
   }
 }
 
-const createWell = async (req, res) => {
-  try { 
-    const well = await Well.create(req.body)
-    res.json({created: well})
-  } catch (error) {
-    res.status(500).send({
-      message: error.message || 'Some error occurred while creating the Well'
-    });
-  }
-}
-
-const getWellDataByWell = async (req, res) => {
+const createWell = async (req, res, next) => {
   try {
-    const well = await Well.findOne({ where: { id: req.params.id } });
-    if (!well) {
-      res.status(404).send({
-        message: 'Well not found'
-      });
-    }
-    //console.log(well.__proto__) -> para conocer los métodos que se pueden usar
-    const wellDataInfo = await well.getWellData()
-    res.json(wellDataInfo)
+    const well = await Well.create(req.body)
+    return res.json({ created: well })
   } catch (error) {
-    res.status(500).send({
-      message: error.message || 'Some error occurred while retrieving Well Data'
-    });
-  
+    return next(error);
   }
 }
 
-const activeOrDesactiveWell = async (req, res) => {
+const getWellDataByWell = async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+      return res.status(400).json({ error: 'Invalid well id' });
+    }
+
+    const well = await Well.findByPk(id);
+    if (!well) {
+      return res.status(404).json({ error: 'Well not found' });
+    }
+
+    const wellDataInfo = await well.getWellData();
+    return res.json(wellDataInfo);
+  } catch (error) {
+    return next(error);
+  }
+}
+
+const activeOrDesactiveWell = async (req, res, next) => {
   try {
     // Get well with full context for activity logging
     const well = await Well.findOne({
@@ -153,11 +149,9 @@ const activeOrDesactiveWell = async (req, res) => {
       console.error('Error creating activity log:', logError);
     }
 
-    res.json(well);
+    return res.json(well);
   } catch (error) {
-    res.status(500).send({
-      message: error.message || 'Some error occurred while activating the Well'
-    });
+    return next(error);
   }
 }
 

--- a/API/src/controllers/wellData.controller.js
+++ b/API/src/controllers/wellData.controller.js
@@ -63,7 +63,7 @@ const normalizeReportNumericFields = (reportData) => {
   };
 };
 
-const createWellData = async (req, res) => {
+const createWellData = async (req, res, next) => {
   try {
     console.log(req.body);
     const well = await Well.findOne({ where: { code: req.body.code } }); // Buscamos el pozo por su código
@@ -92,12 +92,9 @@ const createWellData = async (req, res) => {
     // Normalizar valores numéricos (coma a punto)
     const normalizedData = normalizeReportNumericFields(req.body);
     const wellData = await WellData.create(normalizedData);
-    res.json(wellData);
+    return res.json(wellData);
   } catch (error) {
-    res.status(500).send({
-      message:
-        error.message || "Some error occurred while creating the WellData",
-    });
+    return next(error);
   }
 };
 

--- a/API/src/middlewares/auth.middleware.js
+++ b/API/src/middlewares/auth.middleware.js
@@ -2,31 +2,34 @@ const { decodeToken } = require('../utils/auth.util');
 const { unauthorized, missingToken } = require('../utils/errorcodes.util');
 const ErrorHandler = require('../utils/error.util');
 
-const authMiddleware = (...role) => {
-  return async (req, res, next) => {
+const extractToken = (req) => {
+  const header = req.headers?.authorization;
+  if (!header || typeof header !== 'string') return null;
+  const [scheme, token] = header.split(' ');
+  if (scheme !== 'Bearer' || !token) return null;
+  return token;
+};
+
+const authMiddleware = (...allowedRoles) => {
+  const allowed = allowedRoles.flat();
+  return (req, res, next) => {
     try {
-      if (!req.headers.authorization && (req.body.headers && !req.body.headers.Authorization)) {
-        throw new ErrorHandler(missingToken);
-      }
-      const base = req.headers.authorization ? req.headers.authorization : req.body.headers.Authorization;
-      const token = base.split(' ')[1];
+      const token = extractToken(req);
+      if (!token) throw new ErrorHandler(missingToken);
+
       const decoded = decodeToken(token);
-      if (!decoded) {
+      if (!decoded) throw new ErrorHandler(unauthorized);
+
+      if (allowed.length > 0 && !allowed.includes(decoded.type)) {
         throw new ErrorHandler(unauthorized);
       }
 
-      let userRoles = Array.isArray(role) ? role.flat() : [role];
-
-      if (role.length > 0 && !userRoles.includes(decoded.type)) {
-        throw new ErrorHandler(unauthorized);
-      }
       req.user = decoded;
-      next();
-    } catch (error) {
-      next(error);
+      return next();
+    } catch (err) {
+      return next(err);
     }
   };
-}
+};
 
 module.exports = authMiddleware;
-

--- a/API/src/middlewares/error.middleware.js
+++ b/API/src/middlewares/error.middleware.js
@@ -3,26 +3,42 @@ const ErrorHandler = require('../utils/error.util');
 
 
 const errorHandler = (err, req, res, next) => {
-  // Si se necesita mas detalle para el error, se puede console.log(err)
-  console.log(`Error 🚨 | ${err.message} while sending a ${req.method} to ${req.originalUrl}`);
-  if (err instanceof ValidationError) {
-    const messages = err.errors.map((error) => error.message);
-    return res.status(400).json({ errors: messages });
+  if (res.headersSent) {
+    // Si los headers ya se enviaron, delegamos al default de Express
+    // para que cierre el socket sin intentar un segundo res.send.
+    return next(err);
   }
+
+  console.error(JSON.stringify({
+    level: 'error',
+    method: req.method,
+    url: req.originalUrl,
+    name: err.name,
+    message: err.message,
+    stack: process.env.NODE_ENV === 'production' ? undefined : err.stack,
+  }));
 
   if (err instanceof ErrorHandler) {
     return res.status(err.statusCode).json({ error: err.message });
   }
 
-  if (err instanceof ConnectionError) {
-    return res.status(500).json({ error: err.message });
+  if (err instanceof ValidationError) {
+    const messages = err.errors.map((error) => error.message);
+    return res.status(400).json({ errors: messages });
   }
 
   if (err instanceof DatabaseError) {
-    return res.status(400).json({ error: err.message });
+    return res.status(400).json({ error: 'Invalid request' });
   }
 
-  return res.status(500).json({ error: err.message });
+  if (err instanceof ConnectionError) {
+    return res.status(503).json({ error: 'Service unavailable' });
+  }
+
+  const isProd = process.env.NODE_ENV === 'production';
+  return res.status(500).json({
+    error: isProd ? 'Internal server error' : err.message,
+  });
 };
 
 module.exports = errorHandler

--- a/API/src/server.js
+++ b/API/src/server.js
@@ -2,6 +2,40 @@ const app = require('./app');
 
 const PORT = process.env.PORT || 3000;
 
-app.listen(PORT, () => {
-    console.log(`Escuchando en el puerto ${PORT}`);
+const server = app.listen(PORT, () => {
+  console.log(JSON.stringify({ level: 'info', msg: `API listening on ${PORT}` }));
+});
+
+server.setTimeout(15_000);
+server.keepAliveTimeout = 65_000;
+server.headersTimeout = 66_000;
+
+const shutdown = (signal) => {
+  console.log(JSON.stringify({ level: 'info', msg: `Received ${signal}, shutting down` }));
+  server.close(() => process.exit(0));
+  setTimeout(() => process.exit(1), 10_000).unref();
+};
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+process.on('uncaughtException', (err) => {
+  console.error(JSON.stringify({
+    level: 'fatal',
+    msg: 'uncaughtException',
+    name: err.name,
+    message: err.message,
+    stack: err.stack,
+  }));
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason) => {
+  console.error(JSON.stringify({
+    level: 'fatal',
+    msg: 'unhandledRejection',
+    reason: reason instanceof Error ? reason.message : String(reason),
+    stack: reason instanceof Error ? reason.stack : undefined,
+  }));
+  process.exit(1);
 });

--- a/API/src/services/wellData/handleSendData.service.js
+++ b/API/src/services/wellData/handleSendData.service.js
@@ -10,6 +10,15 @@ dotenv.config();
 const URL_ENDPOINT_V2 =
   "https://apimee.mop.gob.cl/api/v1/mediciones/subterraneas";
 
+// Cliente HTTP dedicado a la DGA con timeout duro de 12s. Evita que un
+// servicio externo lento bloquee indefinidamente al backend (ver
+// timeout reportado por Layrz: "Client.Timeout exceeded while awaiting
+// headers" en POST /wellData).
+const DGA_TIMEOUT_MS = 12_000;
+const dgaClient = axios.create({
+  timeout: DGA_TIMEOUT_MS,
+});
+
 const fixNumberFormat = (number) => {
   if (typeof number !== "number") {
     return number;
@@ -131,7 +140,7 @@ const postToDgaV2 = async (formattedData, codigoObra) => {
     if (!formattedData || typeof formattedData !== "object" || !codigoObra) {
       throw new ErrorHandler(couldntPostToDga);
     }
-    const response = await axios.post(URL_ENDPOINT_V2, formattedData, {
+    const response = await dgaClient.post(URL_ENDPOINT_V2, formattedData, {
       headers: {
         "Content-Type": "application/json",
         codigoObra: codigoObra,
@@ -142,6 +151,13 @@ const postToDgaV2 = async (formattedData, codigoObra) => {
     });
     return response.data;
   } catch (error) {
+    if (error.code === "ECONNABORTED" || error.code === "ETIMEDOUT") {
+      console.error(
+        `Timeout (${DGA_TIMEOUT_MS}ms) enviando a DGA para ${codigoObra}: ${error.message}`
+      );
+      return { error: true, timeout: true, message: error.message };
+    }
+
     console.error("Error al enviar datos a la DGA:", error.message);
 
     if (error.response) {


### PR DESCRIPTION
## Contexto

Este PR cierra dos incidentes recientes en producción y endurece la API contra una familia de problemas relacionados (falta de defensa contra fallas externas y respuestas duplicadas).

### Incidente 1 — crash por `ERR_HTTP_HEADERS_SENT`
La API se caía cuando entraba un GET a `/well/:id` y caía el handler `getWellDataByWell`. El frontend reportaba "network error / CORS" pero la causa raíz era backend: el controlador respondía un 404 sin `return`, ejecutaba `well.getWellData()` sobre `null`, caía al `catch` y enviaba un 500 sobre la respuesta ya cerrada → `ERR_HTTP_HEADERS_SENT` → proceso muerto. Como la API arranca con `nodemon` en producción, el contenedor seguía "Up" pero la app estaba caída esperando file changes, dejando a Nginx sin upstream. Reiniciar el contenedor "arreglaba" el síntoma.

### Incidente 2 — timeout reportado por Layrz
El pod `promedicion-cj-...` (namespace `layrz-outbound`) reportó:

\`\`\`
[CRITICAL] Error POSTing for pozo.cuñifal:
Post "https://promedicionbackend.com/wellData":
context deadline exceeded
(Client.Timeout exceeded while awaiting headers)
\`\`\`

Causa raíz: el endpoint `POST /wellData` quedaba colgado esperando a la API de la DGA. Por dos razones combinadas:

1. El hook `afterCreate` del modelo `wellData` era `async` y `await`-eaba `processAndPostData`, que internamente hace `axios.post` a la DGA. Sequelize espera a los hooks async antes de resolver `WellData.create()`, así que el endpoint esperaba al envío a DGA antes de responder.
2. `axios.post` a la DGA no tenía `timeout` configurado → esperaba indefinidamente.

Resultado: cuando la DGA estaba lenta, el cliente IoT (Layrz) se rendía con "context deadline exceeded" aunque la fila ya estaba en la DB.

## Cambios (7 commits)

| # | Commit | Qué cubre |
|---|---|---|
| 1 | `fix(controllers): prevent ERR_HTTP_HEADERS_SENT in well/wellData/stats` | Causa raíz del incidente 1 |
| 2 | `fix(auth): read bearer token only from Authorization HTTP header` | 500s "Cannot read properties of undefined" en /companies y /clients |
| 3 | `feat(server): handle uncaught exceptions and graceful shutdown` | Que el contenedor caiga de verdad cuando Node muere |
| 4 | `fix(error-middleware): protect against double responses and hide internals in prod` | Red de seguridad ante futuros bugs tipo headers-sent |
| 5 | `feat(app): add explicit 404 handler for unmatched routes` | Higiene contra scanners y typos |
| 6 | `fix(dga): add 12s timeout to axios calls to DGA API` | Causa raíz parcial del incidente 2 |
| 7 | `refactor(welldata): make afterCreate hook fire-and-forget` | Causa raíz principal del incidente 2 |

## Coordinación con el frontend ⚠️

El commit #2 (\`fix(auth)\`) elimina el fallback que leía el token desde \`req.body.headers.Authorization\`. Ese fallback existía para soportar un antipatrón en \`WellProjectFront\` donde varios services pasaban el token dentro del body de POST/PUT por error (firma de 2 argumentos de axios en vez de 3).

El antipatrón se corrige en el PR del frontend: **Emiliax16/WellProjectFront#fix/auth-header-pattern** (4 commits). Endpoints afectados por esa coordinación: crear/editar company, crear/editar distributor, crear/editar client, activar/desactivar well.

**Orden de despliegue obligatorio**: frontend primero (acepta ambos formatos durante la ventana), backend después.

## Notas sobre el commit 7 (fire-and-forget)

El cliente IoT (Layrz) ahora recibe un 200 inmediatamente después de que el reporte se inserta en la DB, **antes** de saber si la DGA confirmó el envío. El envío a DGA ocurre en background con \`setImmediate\` y timeout duro de 12s (commit 6). Si falla o expira, el reporte queda con \`sent: false\` y el SENDER lo recoge en su próxima pasada — no hay pérdida de datos.

Esto baja drásticamente la latencia de \`POST /wellData\` y desacopla el SLA del endpoint del SLA de la DGA.

## Lo que NO entra en este PR (queda para P1)

- Cambiar Dockerfile a \`node\` puro en producción (requiere coordinación de deploy)
- helmet, rate limit, CORS whitelist
- Migrar \`/well\` → \`/wells\` plural
- Regex \`(\d+)\` en \`:id\`
- Healthcheck endpoint
- Logs estructurados con pino
- Tests con supertest

## Test plan

- [ ] Levantar con \`docker-compose up -d --build\`
- [ ] \`curl http://localhost:3000/well/list\` → 404 JSON sin crashear el contenedor
- [ ] \`curl http://localhost:3000/well/999999\` → 404 JSON sin crash
- [ ] \`curl http://localhost:3000/well/<id-existente>\` → 200 con la telemetría
- [ ] \`curl http://localhost:3000/companies\` (sin Authorization) → 401 JSON, no 500
- [ ] \`curl -X POST http://localhost:3000/wellData -H "Content-Type: application/json" -d '{...}'\` → responde en <500ms aunque la DGA esté lenta; el envío ocurre en background
- [ ] Verificar en logs que el envío a DGA ocurre **después** de la respuesta HTTP
- [ ] Forzar uncaughtException → contenedor hace exit + restart en lugar de quedar zombie
- [ ] Verificar que 500s en producción no incluyen \`err.message\` crudo

## Riesgos

| Commit | Riesgo |
|---|---|
| 1 | Muy bajo |
| 2 | Medio si el frontend no se merge antes — mitigado por orden de despliegue |
| 3 | Bajo |
| 4 | Bajo (cambio observable: 500s en prod ya no exponen mensaje interno) |
| 5 | Bajísimo |
| 6 | Bajo (DGA puede tardar legítimamente más de 12s en casos raros — si pasa, queda en \`sent: false\` y SENDER reintenta) |
| 7 | Medio-bajo (cambia el contrato implícito del 200 hacia el cliente IoT — no rompe nada porque el SENDER ya manejaba este caso para bulkCreate) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)