### PR TITLE
fix: cerrar los endpoints públicos que exponían credenciales DGA y permitían borrar reportes

### DIFF
--- a/API/README.md
+++ b/API/README.md
@@ -31,9 +31,24 @@ Estos endpoints quedan abiertos:
 | `POST /massImportWellData` | dispositivos IoT (Layrz) | no tienen forma de autenticarse |
 | `GET /fetchUnsentReports` | servicio SENDER | llama por HTTP sin token |
 | `POST /repostToDGA` | servicio SENDER | llama por HTTP sin token |
+| `GET /well` | ninguno confirmado | ver más abajo |
 | `POST /users/login` | portal | es el que emite el token |
 | `POST /send-email` | landing page | formulario de contacto público |
 | `GET /placeholder` | ninguno | ruta de ejemplo |
+
+**Sobre `GET /well`.** Devolvía el modelo completo del pozo, credenciales DGA
+incluidas, sin pedir sesión. La fuga se cerró excluyendo `password`,
+`rutEmpresa` y `rutUsuario` de la consulta, pero el endpoint se dejó abierto a
+propósito.
+
+El motivo es que no hay forma de saber desde el código qué endpoints consumen
+los dispositivos de Layrz: no aparecen en este repo ni en el del portal. Si
+usaran este listado para sincronizar el catálogo de pozos, cerrarlo cortaría la
+ingesta de telemetría en silencio. Se prefirió dejar expuesto el catálogo
+(nombre, ubicación y código) antes que arriesgar eso.
+
+Para cerrarlo hay que revisar primero los access logs de producción y descartar
+tráfico externo.
 
 Los cuatro primeros deberían pasar a validar un secreto compartido
 (`INTERNAL_API_KEY`) enviado por header. Eso requiere coordinar el cambio con

--- a/API/README.md
+++ b/API/README.md
@@ -16,3 +16,24 @@ El proyecto se basa en la creación de una aplicación que permita gestionar dif
   - [Modo de uso de técnologías](documentations/sequelize-command.md)
 - Instancia de Amazon
   - [Navegación y comandos](documentations/amazon-instance.md)
+
+## Endpoints sin autenticación
+
+Todo el resto de la API exige un JWT válido en el header `Authorization`. Estos
+cuatro endpoints quedan abiertos a propósito porque los consumen procesos que
+hoy no tienen forma de autenticarse:
+
+| Endpoint | Consumidor |
+|---|---|
+| `POST /wellData` | dispositivos IoT (Layrz) |
+| `POST /massImportWellData` | dispositivos IoT (Layrz) |
+| `GET /fetchUnsentReports` | servicio SENDER |
+| `POST /repostToDGA` | servicio SENDER |
+
+Son un pendiente conocido: los cuatro deberían pasar a validar un secreto
+compartido (`INTERNAL_API_KEY`) enviado por header. Eso requiere coordinar el
+cambio con Layrz y con el deploy del SENDER, así que no entra en el hotfix de
+autorización.
+
+Ojo con `POST /wellData` y `POST /massImportWellData`: hoy cualquiera puede
+inyectar telemetría falsa si conoce el `code` de un pozo.

--- a/API/README.md
+++ b/API/README.md
@@ -19,21 +19,43 @@ El proyecto se basa en la creación de una aplicación que permita gestionar dif
 
 ## Endpoints sin autenticación
 
-Todo el resto de la API exige un JWT válido en el header `Authorization`. Estos
-cuatro endpoints quedan abiertos a propósito porque los consumen procesos que
-hoy no tienen forma de autenticarse:
+El resto de la API exige un token válido, que el middleware acepta tanto en el
+header `Authorization` como dentro del body (`body.headers.Authorization`). El
+fallback al body existe porque varios services del portal todavía lo mandan así.
 
-| Endpoint | Consumidor |
-|---|---|
-| `POST /wellData` | dispositivos IoT (Layrz) |
-| `POST /massImportWellData` | dispositivos IoT (Layrz) |
-| `GET /fetchUnsentReports` | servicio SENDER |
-| `POST /repostToDGA` | servicio SENDER |
+Estos endpoints quedan abiertos:
 
-Son un pendiente conocido: los cuatro deberían pasar a validar un secreto
-compartido (`INTERNAL_API_KEY`) enviado por header. Eso requiere coordinar el
-cambio con Layrz y con el deploy del SENDER, así que no entra en el hotfix de
-autorización.
+| Endpoint | Consumidor | Por qué |
+|---|---|---|
+| `POST /wellData` | dispositivos IoT (Layrz) | no tienen forma de autenticarse |
+| `POST /massImportWellData` | dispositivos IoT (Layrz) | no tienen forma de autenticarse |
+| `GET /fetchUnsentReports` | servicio SENDER | llama por HTTP sin token |
+| `POST /repostToDGA` | servicio SENDER | llama por HTTP sin token |
+| `POST /users/login` | portal | es el que emite el token |
+| `POST /send-email` | landing page | formulario de contacto público |
+| `GET /placeholder` | ninguno | ruta de ejemplo |
 
-Ojo con `POST /wellData` y `POST /massImportWellData`: hoy cualquiera puede
-inyectar telemetría falsa si conoce el `code` de un pozo.
+Los cuatro primeros deberían pasar a validar un secreto compartido
+(`INTERNAL_API_KEY`) enviado por header. Eso requiere coordinar el cambio con
+Layrz y con el deploy del SENDER, así que no entra en el hotfix de autorización.
+
+### Consecuencias que conviene tener presentes
+
+**Se puede inyectar telemetría falsa.** `POST /wellData` y `POST
+/massImportWellData` aceptan reportes de cualquiera que conozca el `code` de un
+pozo. Ese código viaja en las respuestas de varios endpoints del portal.
+
+**El reenvío a la DGA sigue siendo disparable sin sesión.**
+`POST /repostAllReportsToDGA` exige sesión, pero `POST /repostToDGA` hace lo
+mismo de a un reporte y queda abierto. Autenticar el primero sube el costo de
+abusar el reenvío, no lo impide. Cerrar el segundo depende del SENDER.
+
+**`POST /send-email` es un relay de correo abierto.** No tiene rate limit ni
+captcha, y despacha desde la cuenta de Gmail configurada en `EMAIL_USER`. Abusarlo
+puede terminar con la cuenta bloqueada por Google.
+
+**Ni el borrado masivo ni el reenvío validan pertenencia.**
+`DELETE /wellData/bulk` y `POST /repostAllReportsToDGA` operan sobre los `id` que
+reciben sin comprobar que los reportes sean de un pozo del cliente que hace la
+petición. Exigen sesión, pero cualquier usuario autenticado puede tocar reportes
+de otro cliente. Los `id` son autoincrementales, así que no hay que adivinarlos.

--- a/API/src/controllers/well.controller.js
+++ b/API/src/controllers/well.controller.js
@@ -43,7 +43,7 @@ const getWellDataByWell = async (req, res) => {
   try {
     const well = await Well.findOne({ where: { id: req.params.id } });
     if (!well) {
-      res.status(404).send({
+      return res.status(404).send({
         message: 'Well not found'
       });
     }

--- a/API/src/controllers/well.controller.js
+++ b/API/src/controllers/well.controller.js
@@ -16,7 +16,10 @@ const Person = db.person;
 //  TODO: no se esta usando ninguno de estos métodos excepto el activeOrDesactiveWell
 const getAllWells = async (req, res) => {
   try {
-    const wells = await Well.findAll();
+    // Las credenciales DGA del pozo nunca salen en un listado
+    const wells = await Well.findAll({
+      attributes: { exclude: ['password', 'rutEmpresa', 'rutUsuario'] }
+    });
     res.json(wells);
   } catch (error) {
     res.status(500).send({

--- a/API/src/controllers/well.controller.js
+++ b/API/src/controllers/well.controller.js
@@ -16,7 +16,9 @@ const Person = db.person;
 //  TODO: no se esta usando ninguno de estos métodos excepto el activeOrDesactiveWell
 const getAllWells = async (req, res) => {
   try {
-    // Las credenciales DGA del pozo nunca salen en un listado
+    // Este listado es global y no filtra por cliente, así que no carga las
+    // credenciales DGA. Los listados por cliente (/clients/:id/wells) sí las
+    // devuelven, porque el formulario de edición del portal las necesita.
     const wells = await Well.findAll({
       attributes: { exclude: ['password', 'rutEmpresa', 'rutUsuario'] }
     });

--- a/API/src/middlewares/auth.middleware.js
+++ b/API/src/middlewares/auth.middleware.js
@@ -5,8 +5,11 @@ const ErrorHandler = require('../utils/error.util');
 const authMiddleware = (...role) => {
   return async (req, res, next) => {
     try {
-      // TODO: eliminar el fallback al body cuando el front deje de mandar el
-      // token ahí (Emiliax16/WellProjectFront#38)
+      // TODO: eliminar el fallback al body sólo cuando estos services del portal
+      // dejen de mandar el token ahí. Ninguno está migrado todavía:
+      //   wellServices.activateWell, companyServices (crear y editar),
+      //   clientServices (crear y editar), distributorService (crear y editar).
+      // El PR WellProjectFront#38 los cubre; #40 no, ese resuelve otra cosa.
       const base = req.headers.authorization || req.body?.headers?.Authorization;
       if (!base) {
         throw new ErrorHandler(missingToken);

--- a/API/src/middlewares/auth.middleware.js
+++ b/API/src/middlewares/auth.middleware.js
@@ -5,11 +5,16 @@ const ErrorHandler = require('../utils/error.util');
 const authMiddleware = (...role) => {
   return async (req, res, next) => {
     try {
-      if (!req.headers.authorization && (req.body.headers && !req.body.headers.Authorization)) {
+      // TODO: eliminar el fallback al body cuando el front deje de mandar el
+      // token ahí (Emiliax16/WellProjectFront#38)
+      const base = req.headers.authorization || req.body?.headers?.Authorization;
+      if (!base) {
         throw new ErrorHandler(missingToken);
       }
-      const base = req.headers.authorization ? req.headers.authorization : req.body.headers.Authorization;
       const token = base.split(' ')[1];
+      if (!token) {
+        throw new ErrorHandler(missingToken);
+      }
       const decoded = decodeToken(token);
       if (!decoded) {
         throw new ErrorHandler(unauthorized);

--- a/API/src/routes/user.route.js
+++ b/API/src/routes/user.route.js
@@ -21,7 +21,7 @@ const {
 console.log(...AdminAndCompany);
 const router = express.Router();
 
-router.get('/users', getUsers);
+router.get('/users', authMiddleware(...Admin), getUsers);
 router.get('/users/data', authMiddleware(...AllRoles), getUserInfo);
 router.get('/users/data/:id', authMiddleware(...AllRoles), getUserInfoById);
 router.post('/users/register',  authMiddleware(...AdminAndCompanyAndDistributor), validateParams(registerParams, true), registerUser);

--- a/API/src/routes/well.route.js
+++ b/API/src/routes/well.route.js
@@ -8,13 +8,14 @@ const {
   activeOrDesactiveWell,
 } = require('../controllers/well.controller');
 const {
+  Admin,
   AdminAndCompanyAndNormal,
 } = require('../utils/allowed-roles.util');
 
 const router = express.Router();
 
-router.get('/well', getAllWells);
-router.get('/well/:id', getWellDataByWell);
+router.get('/well', authMiddleware(...Admin), getAllWells);
+router.get('/well/:id', authMiddleware(...AdminAndCompanyAndNormal), getWellDataByWell);
 router.post('/well', authMiddleware(...AdminAndCompanyAndNormal), createWell);
 router.put('/wells/:id/active', authMiddleware(...AdminAndCompanyAndNormal), activeOrDesactiveWell);
 

--- a/API/src/routes/well.route.js
+++ b/API/src/routes/well.route.js
@@ -8,13 +8,15 @@ const {
   activeOrDesactiveWell,
 } = require('../controllers/well.controller');
 const {
-  Admin,
   AdminAndCompanyAndNormal,
 } = require('../utils/allowed-roles.util');
 
 const router = express.Router();
 
-router.get('/well', authMiddleware(...Admin), getAllWells);
+// Sin JWT a propósito: no está confirmado que los dispositivos IoT no lo usen
+// para sincronizar el catálogo de pozos (ver README). El controlador excluye
+// las credenciales DGA, que era la fuga real.
+router.get('/well', getAllWells);
 router.get('/well/:id', authMiddleware(...AdminAndCompanyAndNormal), getWellDataByWell);
 router.post('/well', authMiddleware(...AdminAndCompanyAndNormal), createWell);
 router.put('/wells/:id/active', authMiddleware(...AdminAndCompanyAndNormal), activeOrDesactiveWell);

--- a/API/src/routes/wellData.route.js
+++ b/API/src/routes/wellData.route.js
@@ -1,5 +1,6 @@
 const express = require("express");
 
+const authMiddleware = require("../middlewares/auth.middleware");
 const {
   createWellData,
   bulkCreateWellData,
@@ -8,13 +9,21 @@ const {
   repostAllReportsToDGA,
   bulkDeleteWellData,
 } = require("../controllers/wellData.controller");
+const {
+  AdminAndCompanyAndNormal,
+} = require("../utils/allowed-roles.util");
 const router = express.Router();
 
+// Ingesta desde los dispositivos IoT: sin JWT a propósito (ver README)
 router.post("/wellData", createWellData);
-router.get("/fetchUnsentReports", fetchUnsentReports);
-router.post("/repostAllReportsToDGA", repostAllReportsToDGA);
-router.post("/repostToDGA", repostToDGA);
 router.post("/massImportWellData", bulkCreateWellData);
-router.delete("/wellData/bulk", bulkDeleteWellData);
+
+// Consumidos por el servicio SENDER: sin JWT a propósito (ver README)
+router.get("/fetchUnsentReports", fetchUnsentReports);
+router.post("/repostToDGA", repostToDGA);
+
+// Acciones disparadas desde el portal: requieren sesión
+router.post("/repostAllReportsToDGA", authMiddleware(...AdminAndCompanyAndNormal), repostAllReportsToDGA);
+router.delete("/wellData/bulk", authMiddleware(...AdminAndCompanyAndNormal), bulkDeleteWellData);
 
 module.exports = router;


### PR DESCRIPTION
## Issues relacionados

Sin ticket de Jira asociado.

Depende de **Emiliax16/WellProjectFront#40**, que debe desplegarse antes (ver "Orden de
despliegue" más abajo).

> **Actualizado tras auditoría QA independiente.** `GET /well` vuelve a quedar público (sin
> credenciales) para no arriesgar la ingesta de Layrz, y se corrigió el inventario del README.
> Detalle al final, en "Cambios tras la auditoría".

## Descripción del problema: cinco endpoints en producción respondían sin pedir sesión

El más grave es `GET /well`. Está sin `authMiddleware` y el controlador hace `Well.findAll()` sin
filtrar columnas, así que devuelve el modelo completo del pozo. Ese modelo incluye `password`,
`rutEmpresa` y `rutUsuario`: las credenciales con las que el sistema se autentica ante la DGA en
nombre de cada cliente.

Está verificado contra producción, no es teórico. Un `curl` sin cabeceras a
`https://promedicionbackend.com/well` devolvía los 8 pozos registrados, los 8 con credenciales
pobladas. Las credenciales deben considerarse comprometidas y hay que rotarlas.

El segundo problema serio es `DELETE /wellData/bulk`. Se agregó en enero junto al borrado masivo del
portal (`40f017f`) y quedó sin `authMiddleware`, así que cualquiera puede borrar reportes de
telemetría conociendo sus IDs. Sobre datos que alimentan un reporte regulatorio, eso es destrucción
de información sin rastro.

Los otros tres son de menor impacto pero del mismo tipo:

- `GET /users`: expone los 12 usuarios con nombre, email y rol. No filtra contraseñas.
- `GET /well/:id`: expone la telemetría completa de cualquier pozo por ID.
- `POST /repostAllReportsToDGA`: permite forzar reenvíos a la DGA.

## Solución propuesta: cerrar lo que nadie externo consume y documentar lo que queda abierto

El criterio para decidir qué cerrar fue el consumidor real de cada endpoint, no su nombre. Revisé
los tres consumidores: el portal (`WellProjectFront`), el servicio SENDER y los dispositivos IoT de
Layrz.

**Los cinco endpoints cerrados**

| Endpoint | Rol exigido | Consumidor |
|---|---|---|
| `GET /well/:id` | admin, company, normal | ninguno |
| `GET /users` | admin | ninguno |
| `POST /repostAllReportsToDGA` | admin, company, normal | portal |
| `DELETE /wellData/bulk` | admin, company, normal | portal |

Los dos primeros no los llama nadie: el portal no los referencia y el SENDER tampoco. Cerrarlos no
rompe nada. Los dos últimos sí los llama el portal, y ahí está la coordinación con el PR del
frontend.

**`GET /well` queda público a propósito, pero sin credenciales.** La consulta excluye `password`,
`rutEmpresa` y `rutUsuario`, que era la fuga real. El endpoint sigue respondiendo sin token porque
no hay forma de verificar desde el código qué consume Layrz, y si usara este listado para
sincronizar el catálogo de pozos, cerrarlo cortaría la ingesta en silencio. Lo que queda expuesto
es el catálogo: nombre, ubicación y código.

**Los cuatro endpoints que quedan abiertos, a propósito**

`POST /wellData` y `POST /massImportWellData` los usan los dispositivos IoT de Layrz. `GET
/fetchUnsentReports` y `POST /repostToDGA` los usa el SENDER, que hoy llama por `http://` sin
ningún token (`SENDER/wellproject/app/models/sender.rb`).

Protegerlos requiere un secreto compartido coordinado con Layrz y con el deploy del SENDER. Meter
eso en este PR arriesga cortar el envío a la DGA, que es una obligación regulatoria. Quedan
listados en el README con su consumidor y el pendiente concreto, para que no se lean como descuido.

**Dos arreglos de estabilidad que entran por arrastre**

`getWellDataByWell` respondía su 404 sin `return`, seguía ejecutando `well.getWellData()` sobre
`null` y terminaba mandando un 500 sobre una respuesta ya cerrada. Eso lanza `ERR_HTTP_HEADERS_SENT`
y mata el proceso de Node. Como producción arranca con nodemon, el contenedor quedaba "Up" pero sin
app escuchando. Es el mismo arreglo del PR #54; se incluye porque el handler se está tocando igual.

El `authMiddleware` leía `req.body.headers` antes de comprobar que existiera, así que una petición
sin token respondía 500 en vez de 401. Con cinco rutas nuevas exigiendo sesión eso pasaba de ser un
detalle a ser el comportamiento visible. **Se mantiene a propósito el fallback que lee el token
desde el body**: varios services del portal todavía lo mandan así, y quitarlo los rompería hasta que
se despliegue Emiliax16/WellProjectFront#38. Queda marcado con un TODO.

## Screenshots

No aplica, no hay cambios visuales.

## Cómo probar

**1. Levantar el stack**

```bash
docker-compose up -d --build
docker-compose logs -f api
```

**2. Confirmar que los cuatro endpoints cerrados ahora piden sesión**

Todos deben responder `401` con `{"message":"Token no encontrado."}`:

```bash
curl -i http://localhost:3000/well/1
curl -i http://localhost:3000/users
curl -i -X POST http://localhost:3000/repostAllReportsToDGA \
  -H 'Content-Type: application/json' -d '{"reports":[]}'
curl -i -X DELETE http://localhost:3000/wellData/bulk \
  -H 'Content-Type: application/json' -d '{"reportIds":[1]}'
```

Lo importante es que sea **401 y no 500**. Un 500 significa que el arreglo del middleware no quedó.

**3. Confirmar que `GET /well` sigue público pero sin credenciales**

```bash
curl -s http://localhost:3000/well | jq '.[0] | keys'
```

Debe responder `200` **sin token** — si da 401, se rompe la ingesta de Layrz. Y no deben aparecer
`password`, `rutEmpresa` ni `rutUsuario`. El resto de los campos sí.

**4. Confirmar que un rol insuficiente no pasa**

Con un token de rol `normal`, `GET /users` debe dar `401`. Con el de admin, `200`.

```bash
TOKEN=$(curl -s -X POST http://localhost:3000/users/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"<tu-admin>","password":"<tu-password>"}' | jq -r .token)
```

**5. Confirmar que el 404 ya no tumba el proceso**

```bash
curl -i http://localhost:3000/well/999999 -H "Authorization: Bearer $TOKEN"
docker-compose ps
```

Debe responder `404` en JSON y el contenedor debe seguir respondiendo después. Antes de este cambio
el proceso moría y las peticiones siguientes quedaban sin upstream.

**6. Confirmar en el portal que nada se rompió**

Con el frontend de la rama `fix/enviar-token-en-endpoints-de-reportes` levantado:

- Enviar reportes a la DGA desde la vista de reportes de un pozo → 200
- Seleccionar reportes y borrarlos → 200
- Listar clientes, pozos y reportes → sin cambios

**Verificación ya hecha**

Levanté el app de Express en proceso y corrí 12 casos de autorización (sin token, rol insuficiente,
token basura, token admin, y los tres que confirman que `/well` sigue abierto): pasan los 12.
Confirmé además que `GET /well` sin token ya no devuelve los tres campos sensibles. No pude levantar
Docker en mi entorno, así que los pasos 1 y 5 quedan sin verificar de mi lado.

## Orden de despliegue: frontend primero

**Emiliax16/WellProjectFront#40 debe mergearse y desplegarse antes que este PR.**

El backend actual no exige token en `POST /repostAllReportsToDGA` ni en `DELETE /wellData/bulk`, y
el portal actual no lo manda. Con este PR desplegado, ambas acciones responderían 401 hasta que el
frontend se actualice.

El frontend nuevo funciona contra el backend viejo sin problema: manda un header que el backend
todavía ignora. Por eso la ventana intermedia es segura en ese sentido, y solo en ese.

## Riesgos y pendientes

**Riesgo de romper un consumidor que no encontré**

Busqué referencias en el portal y en el SENDER, y no aparecen fuera de los dos casos ya cubiertos.
El riesgo que queda es un consumidor externo no documentado — en la práctica, Layrz. Por eso `GET
/well` se dejó abierto. Los otros cuatro endpoints son mucho menos plausibles como dependencia de
un dispositivo de telemetría: `/users` lista usuarios, `/well/:id` usa el id autoincremental interno
(Layrz identifica pozos por `code`), y los dos del portal reciben `reportIds` que un dispositivo no
tiene. Si aun así alguno se rompe, se manifiesta como 401 inmediato y se revierte en un commit.

**Pendientes que este PR no cubre**

- Rotar las credenciales DGA de los 8 pozos, una vez desplegado. Estuvieron públicas.
- Revisar los access logs de producción de `GET /well` para poder cerrarlo del todo.
- Agregar validación de pertenencia en `DELETE /wellData/bulk` y `POST /repostAllReportsToDGA`.
  Hoy exigen sesión pero no comprueban que los reportes sean del cliente que pide, y los `id` son
  autoincrementales. Va en un PR aparte para no ampliar este.
- Autenticar los cuatro endpoints de IoT y SENDER con un secreto compartido.
- El PR #54 sigue abierto y con conflictos. Este PR toca dos de sus archivos, así que va a necesitar
  rebase.
- Quitar el fallback de token en el body, una vez desplegado WellProjectFront#38.

## Cambios tras la auditoría QA

Se auditó la rama con un revisor independiente, sin contexto de cómo se escribió. Confirmó que no
hay regresiones en el middleware, que el contrato con el PR del front calza, que el filtrado de
campos no rompe ninguna vista y que el SENDER queda intacto. Los cambios que sí motivó:

- **`GET /well` vuelve a ser público**, sin credenciales. No se puede verificar desde el código qué
  consume Layrz, así que cerrarlo era el único riesgo real de cortar la ingesta.
- **El README estaba incorrecto.** Decía que sólo cuatro endpoints quedaban abiertos, cuando también
  lo están `/users/login`, `/send-email` y `/placeholder`. Y omitía que el middleware acepta el
  token en el body, no sólo en el header.
- **`POST /send-email` es un relay de correo abierto**, sin rate limit, sobre la cuenta de Gmail
  configurada. Queda anotado como pendiente.
- **El TODO del middleware subestimaba el trabajo.** Sugería que el fallback al body se podía
  eliminar tras WellProjectFront#38, cuando ninguno de los seis services está migrado. Ahora los
  lista, para que nadie lo borre y rompa la activación de pozos y la creación de empresas.
- **Se documentó la falta de validación de pertenencia** en el borrado masivo y el reenvío.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
