### PR TITLE
hotfix: restaurar la verificación de contraseña en el login

### DIFF
--- a/API/src/controllers/user.controller.js
+++ b/API/src/controllers/user.controller.js
@@ -347,10 +347,10 @@ const loginUser = async (req, res, next) => {
     if (!user) {
       throw new ErrorHandler(userNotFound);
     }
-    // const isValid = await user.checkPassword(password);
-    // if (!isValid) {
-    //   throw new ErrorHandler(passwordsDontMatch);
-    // }
+    const isValid = await user.checkPassword(password);
+    if (!isValid) {
+      throw new ErrorHandler(passwordsDontMatch);
+    }
     const role = await user.getRole();
     if (role.type !== "admin" && !user.isActived) {
       throw new ErrorHandler(unauthorized);


### PR DESCRIPTION
> ⚠️ **Bypass de autenticación activo en producción.** Este PR va solo, sin depender de ningún otro,
> para que pueda desplegarse de inmediato.

## Issues relacionados

Sin ticket de Jira asociado. Encontrado mientras se depuraba un problema de login en local.

No depende de #56 ni de WellProjectFront#40, y no los bloquea. Es un cambio de 4 líneas en un
archivo que ninguno de esos PR toca.

## Descripción del problema: cualquiera puede entrar como cualquier usuario

En `src/controllers/user.controller.js`, el bloque que compara la contraseña contra el hash está
comentado:

```js
// const isValid = await user.checkPassword(password);
// if (!isValid) {
//   throw new ErrorHandler(passwordsDontMatch);
// }
```

`POST /users/login` sólo comprueba que el email exista y que el usuario esté activo. Después emite
el JWT. **Cualquier contraseña sirve.** Verificado en local contra la rama `master`: cuatro
contraseñas inventadas distintas, las cuatro devuelven `201` con un token válido.

El token que se emite es el real, con el rol real del usuario. Si el email pertenece a un admin, el
atacante obtiene una sesión de admin sobre todo el sistema.

**Los emails no son un secreto.** `GET /users` los devuelve y estuvo público hasta #56. Un atacante
que hubiera consultado ese endpoint tiene la lista completa de cuentas y puede entrar en cualquiera.

### Cuándo entró

Commit `9b32b42` (2025-11-23), dentro del PR de activity logs. El commit no menciona el login y el
cambio no guarda relación con la funcionalidad que agrega, así que parece una prueba local que se
coló en el merge. Está en `master` desde entonces, que es lo que corre en producción.

## Solución propuesta

Descomentar el bloque, sin tocar nada más. `user.checkPassword` (`models/user.js:106`) y
`passwordsDontMatch` (`utils/errorcodes.util.js:8`) siguen existiendo y ya estaban importados en el
controlador, así que no hace falta ningún cambio adicional.

`checkPassword` usa `bcrypt.compare` contra `encrypted_password`, que sigue poblado y hasheado
correctamente para todos los usuarios. Verifiqué los 4 usuarios de mi base local: los 4 tienen un
hash bcrypt válido de 60 caracteres. **No hay que resetear contraseñas** — las que estaban
guardadas vuelven a funcionar tal cual.

## Screenshots

<img width="2350" height="915" alt="image" src="https://github.com/user-attachments/assets/ba7fc6c9-e439-4381-aaa2-31258817b2f3" />

## Cómo probar

**1. Confirmar el bug en `master` antes de mergear**

```bash
git checkout master && docker-compose up -d --build

curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:3000/users/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"<un-email-que-exista>","password":"esto-no-es-la-clave"}'
```

Devuelve `201`. Ese es el bug.

**2. Confirmar que esta rama lo corrige**

```bash
git checkout hotfix/restaurar-verificacion-de-contrasena-en-login && docker-compose up -d --build
```

Repetir el `curl` anterior → ahora `400` con `{"error":"Contraseña incorrecta."}`.

**3. Confirmar que un login legítimo sigue funcionando**

```bash
curl -s -X POST http://localhost:3000/users/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"<tu-email>","password":"<tu-clave-real>"}' | jq '{status:"ok", tieneToken:(.token != null)}'
```

Debe devolver `201` con token. Probar con un usuario de cada rol (admin, company, normal) para
descartar que alguna cuenta tenga el hash corrupto.

**4. Confirmar el flujo completo desde el portal**

Entrar al portal con credenciales correctas → entra. Con una contraseña equivocada → muestra
"Contraseña incorrecta." en vez de dejar pasar.

**Verificación ya hecha**

Creé un usuario temporal con contraseña conocida y probé los dos caminos contra el app real:

| Caso | Resultado |
|---|---|
| La contraseña se guarda hasheada (bcrypt, no plano) | PASS |
| Contraseña incorrecta | PASS — `400 "Contraseña incorrecta."` |
| Contraseña vacía | PASS — `400` |
| Contraseña correcta | PASS — `201` con token |
| La respuesta no incluye `encrypted_password` | PASS |

El usuario temporal se eliminó al terminar. No pude levantar Docker en mi entorno, así que los pasos
1 y 2 con contenedores quedan sin verificar de mi lado; el resto corrió contra el app de Express y
la base local.

## Riesgos

**Del cambio en sí: bajos.** Restaura un comportamiento que el sistema tuvo hasta noviembre de 2025.
El único escenario de rotura es una cuenta cuyo `encrypted_password` esté corrupto o vacío: esa
persona quedaría sin poder entrar. Vale la pena revisar en producción antes de desplegar:

```sql
SELECT id, email FROM users
WHERE encrypted_password IS NULL OR encrypted_password !~ '^\$2[aby]\$';
```

Si devuelve filas, hay que resetearles la contraseña por separado. En mi base local devuelve 0.

**De no desplegarlo: altos.** El bypass sigue abierto mientras tanto.

## Después de desplegar

- **Revisar los access logs** de `POST /users/login` desde noviembre de 2025, buscando accesos desde
  IPs desconocidas. El bypass no deja rastro propio: un login abusivo se ve idéntico a uno legítimo.
- **Considerar invalidar las sesiones vivas.** Los JWT emitidos durante la ventana siguen siendo
  válidos hasta 24h después de emitidos. Rotar `JWT_SECRET` los invalida todos de una, a costa de
  obligar a todo el mundo a volver a entrar.
- **Avisar a los usuarios** si el log muestra algo raro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
