### PR TITLE
fix: agregar timeout de 12s a las llamadas a la API de la DGA

### DIFF
--- a/API/src/services/wellData/handleSendData.service.js
+++ b/API/src/services/wellData/handleSendData.service.js
@@ -10,6 +10,15 @@ dotenv.config();
 const URL_ENDPOINT_V2 =
   "https://apimee.mop.gob.cl/api/v1/mediciones/subterraneas";
 
+// Cliente HTTP dedicado a la DGA con timeout duro de 12s. Evita que un
+// servicio externo lento bloquee indefinidamente al backend (ver
+// timeout reportado por Layrz: "Client.Timeout exceeded while awaiting
+// headers" en POST /wellData).
+const DGA_TIMEOUT_MS = 12_000;
+const dgaClient = axios.create({
+  timeout: DGA_TIMEOUT_MS,
+});
+
 const fixNumberFormat = (number) => {
   if (typeof number !== "number") {
     return number;
@@ -131,7 +140,7 @@ const postToDgaV2 = async (formattedData, codigoObra) => {
     if (!formattedData || typeof formattedData !== "object" || !codigoObra) {
       throw new ErrorHandler(couldntPostToDga);
     }
-    const response = await axios.post(URL_ENDPOINT_V2, formattedData, {
+    const response = await dgaClient.post(URL_ENDPOINT_V2, formattedData, {
       headers: {
         "Content-Type": "application/json",
         codigoObra: codigoObra,
@@ -142,6 +151,13 @@ const postToDgaV2 = async (formattedData, codigoObra) => {
     });
     return response.data;
   } catch (error) {
+    if (error.code === "ECONNABORTED" || error.code === "ETIMEDOUT") {
+      console.error(
+        `Timeout (${DGA_TIMEOUT_MS}ms) enviando a DGA para ${codigoObra}: ${error.message}`
+      );
+      return { error: true, timeout: true, message: error.message };
+    }
+
     console.error("Error al enviar datos a la DGA:", error.message);
 
     if (error.response) {


### PR DESCRIPTION
## Issues relacionados

Sin ticket de Jira asociado.

Rescata **un** commit del **#54**, que quedó basado en un `master` de abril y no se puede rebasear sin
riesgo. Los otros seis quedan pendientes (ver el final).

## Descripción del problema: las llamadas a la DGA pueden esperar para siempre

El cliente IoT de Layrz reportó desde producción:

```
[CRITICAL] Error POSTing for pozo.cuñifal:
Post "https://promedicionbackend.com/wellData":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

La fila ya estaba en la base, pero el cliente se rindió esperando.

`POST /wellData` dispara el hook `afterCreate` del modelo, que envía el reporte a la DGA de forma
síncrona. Ese envío usa `axios.post` **sin `timeout` configurado**, y el default de axios es esperar
indefinidamente. Si la API del MOP se cuelga, la petición de Layrz se cuelga con ella.

Sigue presente en `master` hoy: `grep -c timeout handleSendData.service.js` → `0`.

## Solución propuesta: acotar la espera a 12 segundos

Se crea un cliente axios dedicado a la DGA con `timeout: 12_000` y se captura `ECONNABORTED` /
`ETIMEDOUT` como un caso propio, devolviendo `{ error: true, timeout: true }` con un log explícito.

Ese valor viaja a `checkValidResponseV2`, que lo trata como fallo, así que `processAndPostData`
lanza `couldntPostToDga` y **el reporte queda con `sent: false`**. Es exactamente el mismo estado en
el que queda hoy cualquier otro fallo de envío, así que no se introduce ningún camino nuevo.

## Alcance: qué NO cambia

Este PR toca **un archivo** y no altera ningún comportamiento observable salvo el que busca: dejar
de esperar para siempre.

- **El cuerpo de las respuestas.** Verificado midiendo contra `master`: `POST /wellData` sigue
  devolviendo `sent: true` con su `sentDate` cuando la DGA acepta. Idéntico.
- **Cuándo responde el endpoint.** El envío sigue siendo síncrono. Un fallo de la DGA le sigue
  llegando al cliente, no se vuelve silencioso.
- **El formato de los datos enviados.** Ni una línea de `formaDataV2`.
- **La importación masiva.** `bulkCreate` no usa `individualHooks`, así que nunca disparó el envío.
- **Autenticación, rutas y permisos.** No se toca ningún endpoint.
- **El modelo `wellData`.** Sin cambios.

## Screenshots

No aplica.

## Cómo probar

**1. Que el timeout esté configurado**

```bash
grep -n "timeout" API/src/services/wellData/handleSendData.service.js
```
Debe aparecer `DGA_TIMEOUT_MS = 12_000` y el `axios.create({ timeout: DGA_TIMEOUT_MS })`.

**2. Que un envío normal siga funcionando igual**

Con un pozo activo, mandar un reporte y confirmar que la respuesta trae `sent: true` y `sentDate`,
igual que antes.

⚠️ Este paso transmite de verdad al MOP. Para probarlo sin transmitir, intercepta axios o usa un
pozo desactivado.

**3. Que un cuelgue de la DGA se corte a los 12s**

Apuntar `URL_ENDPOINT_V2` a un servidor local que acepte la conexión y nunca responda. La llamada
debe abortar a los ~12s con `ECONNABORTED`, loguear el timeout, y el reporte quedar `sent: false`.

**Verificación ya hecha**

- El cliente axios se crea con `timeout: 12000`.
- Contra un servidor que nunca responde, aborta al cumplirse el timeout con `ECONNABORTED` y sin
  `error.response`, que es la rama del `catch` que se agregó.
- La cadena completa del valor de retorno hasta el estado en base: `{error:true,timeout:true}` →
  `checkValidResponseV2` → `false` → `couldntPostToDga` → `sent: false`. Sin falsos positivos.
- Respuesta de `POST /wellData` comparada contra `master`: idéntica (`sent=true` + `sentDate`).
- Regresión sobre lo ya desplegado: 12/12 de autorización, credenciales DGA filtradas, ingesta y
  endpoints del SENDER intactos. Ninguna llamada salió a internet en ninguna corrida.

## Efectos secundarios a tener presentes

**El timeout también aplica a los reenvíos.** El cliente es compartido, así que `POST /repostToDGA` y
`POST /repostAllReportsToDGA` también quedan con tope de 12s. Un reenvío que antes tardaba 20s ahora
falla. En la práctica ya fallaba: el `Net::HTTP` del SENDER tiene `read_timeout` de 60s por defecto y
levanta excepción igual. Este cambio hace que ocurra antes, no que ocurra por primera vez.

**12s puede quedar corto para una API de gobierno.** Si pasa, el reporte queda `sent: false` y se
puede reenviar. Vale considerar moverlo a variable de entorno más adelante: hoy es una constante
hardcodeada, y este sistema se despliega cada varios meses, así que no habría forma de ajustarlo
durante un incidente.

**Un timeout de cliente no significa que la DGA no procesó el dato.** Si expira después de que el MOP
lo recibió, un reenvío genera un duplicado. No hay clave de idempotencia en el envío. Es un riesgo
preexistente que este cambio hace un poco más probable.

## Lo que NO entra, y por qué

Se evaluó incluir también el desacople del hook (`fire-and-forget`, commit `7b8c4be` del #54), que
haría que `POST /wellData` responda de inmediato sin esperar a la DGA. **Se descartó para esta
entrega** por dos razones concretas:

- **El respaldo no existe.** El desacople se apoya en que el SENDER reintente los reportes con
  `sent: false`. Pero `SENDER/wellproject/config/schedule.rb` no tiene ningún bloque `every` activo y
  el Dockerfile nunca corre `whenever --update-crontab`. Sin ese reintento, cada fallo de la DGA
  pasaría de error visible a pérdida silenciosa. Hay que confirmar `crontab -l` en la instancia antes
  de considerarlo.
- **Cambia el cuerpo de la respuesta.** Medido contra `master`: `POST /wellData` pasaría a devolver
  `sent: false, sentDate: null` en vez de `sent: true`. Afecta también a
  `POST /clients/:id/wells/:code/add`. El portal no se rompe porque lee `sent` del listado, pero no
  tenemos el código de Layrz.

## Pendientes del #54, para después

Cada uno rehecho sobre el código actual, no rebaseado:

- `uncaughtException`, `unhandledRejection` y apagado ordenado en `server.js`, **conservando
  `startSchedulers()`**. Es prerequisito del desacople.
- Guard de `headersSent` en el error middleware y ocultar internals en producción.
- 404 explícito en `app.js`, **conservando `monitoringRoute`**.
- Leer el token sólo del header — requiere WellProjectFront#38 desplegado antes.
- El desacople del hook, una vez confirmado el cron del SENDER.

Detectados de paso, fuera del alcance de este PR:

- `handleSendData.service.js:85,87,114` imprimen la contraseña de la DGA y los RUTs en cada envío.
- `fetchUnsentReports` exige `editStatusDate NOT NULL`, así que un pozo activo sin ese campo nunca
  recupera sus reportes fallidos.
- `runAlertCheck` alerta por pozos sin comunicación, pero no por reportes que nunca llegaron a la
  DGA. Ese modo de falla hoy es invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
