### PR TITLE
fix: deja de imprimir credenciales DGA y contraseñas de usuario en los logs

### DIFF
--- a/API/models/welldata.js
+++ b/API/models/welldata.js
@@ -71,10 +71,13 @@ module.exports = (sequelize, DataTypes) => {
               await processAndPostData(wellData, well);
             }
           } catch (error) {
-            // Sólo el mensaje: un error de axios arrastra `config.data`, que
-            // lleva las credenciales DGA del pozo.
+            // Nunca loguear el error completo: si alguna vez llega hasta acá
+            // un error de axios sin pasar por postToDgaV2, `util.inspect` lo
+            // expande e imprime `config.data`, o sea el cuerpo enviado con las
+            // credenciales DGA dentro. `error.stack` no las arrastra, así que
+            // sí se puede conservar la traza.
             console.error(
-              `[dga] falló el envío automático del reporte ${wellData.id} (${wellData.code}): ${error.message}`
+              `[dga] falló el envío automático del reporte ${wellData.id} (${wellData.code}): ${error.stack || error.message}`
             );
           }
         },

--- a/API/models/welldata.js
+++ b/API/models/welldata.js
@@ -71,7 +71,11 @@ module.exports = (sequelize, DataTypes) => {
               await processAndPostData(wellData, well);
             }
           } catch (error) {
-            console.log(error);
+            // Sólo el mensaje: un error de axios arrastra `config.data`, que
+            // lleva las credenciales DGA del pozo.
+            console.error(
+              `[dga] falló el envío automático del reporte ${wellData.id} (${wellData.code}): ${error.message}`
+            );
           }
         },
       },

--- a/API/src/controllers/user.controller.js
+++ b/API/src/controllers/user.controller.js
@@ -138,7 +138,6 @@ const registerUser = async (req, res, next) => {
 
   try {
     const { id: requesterId, type: requesterRole } = req.user;
-    console.log("receiving this body:", req.body);
     if (!checkPermissionsForClientResources(req.user, undefined, true)) {
       throw new ErrorHandler(unauthorized);
     }
@@ -154,7 +153,8 @@ const registerUser = async (req, res, next) => {
     };
 
     const role = await Role.findByPk(userParams.roleId, { transaction });
-    console.log("\n\nUSER Y ROLE!!!!!!\n\n:", userParams, role, req.body);
+    // `userParams` y `req.body` llevan `encrypted_password` sin hashear.
+    console.log(`[users] registrando ${userParams.email} con rol ${role?.type}`);
 
     if (!role) {
       throw new ErrorHandler(userNotFound);

--- a/API/src/middlewares/validate-params.middleware.js
+++ b/API/src/middlewares/validate-params.middleware.js
@@ -15,8 +15,9 @@ function validateParams(paramsSpec, registerUser = false) {
     // hacer una excepción, puesto que si el usuario es normal o admin, se
     // necesitan parámetros de Person, pero si es empresa, se necesitan parámetros
     // de Company
-    console.log('THIS IS THE REQ.BODY', req.body);
-    
+    // No loguear `req.body`: este middleware corre en /users/login y
+    // /users/register (contraseña del usuario en texto plano) y en la
+    // creación y edición de pozos (credenciales DGA).
 
     let type = req.body.roleType;
 

--- a/API/src/services/wellData/handleSendData.service.js
+++ b/API/src/services/wellData/handleSendData.service.js
@@ -82,11 +82,16 @@ const normalizeHourFormat = (hour) => {
 const processAndPostData = async (wellData, well) => {
   try {
     const data = { ...well.toJSON(), ...wellData.toJSON() };
-    console.log("Data to be sent:", data);
+    // Nunca loguear `data` ni `formatedData`: ambos llevan las credenciales
+    // DGA del pozo (password, rutEmpresa, rutUsuario) en texto plano.
+    console.log(
+      `[dga] enviando reporte ${wellData.id} | pozo ${wellData.code} | ${wellData.date} ${wellData.hour}`
+    );
     const formatedData = await formaDataV2(data);
-    console.log("Formatted data:", formatedData);
     const response = await postToDgaV2(formatedData, wellData.code);
-    console.log("Response from DGA:", response.data);
+    console.log(
+      `[dga] respuesta reporte ${wellData.id} | status ${response?.status} | ${response?.message ?? "sin mensaje"}`
+    );
     if (!checkValidResponseV2(response))
       throw new ErrorHandler(couldntPostToDga);
     await wellData.update({
@@ -111,7 +116,6 @@ const processAndPostData = async (wellData, well) => {
  * @returns {Object} - Retorna un objeto JSON formateado listo para ser enviado a la DGA.
  */
 const formaDataV2 = async (data) => {
-  console.log("this is the data", data);
   const fecha = data.realDate || data.date;
   return {
     autenticacion: {
@@ -285,7 +289,7 @@ const formatRequest = async (data) => {
         },
       },
     });
-    console.log("---- XML ----\n", xml);
+    // El XML incluye `aut1:password`, así que no se loguea.
     return xml;
   } catch (error) {
     throw error;


### PR DESCRIPTION
## Issues relacionados

Cierra **#61**. Sin ticket de Jira asociado.

Independiente del resto de los issues abiertos: no toca permisos, rutas ni contratos de API.

## Descripción del problema: las contraseñas se escriben en los logs ~1.440 veces al día

El servicio de envío a la DGA imprime el objeto completo del pozo antes de transmitir, y ese objeto
incluye `password`, `rutEmpresa` y `rutUsuario`: las credenciales con las que el sistema se
autentica ante el regulador en nombre de cada cliente.

Con un pozo emitiendo cada minuto, la contraseña queda escrita del orden de 1.440 veces al día en
los logs del contenedor. Esos logs se leen con `docker logs`, se pegan en tickets, en PRs y en
chats de soporte. Cada vez que alguien comparte un log para pedir ayuda, filtra credenciales de un
cliente.

**Estas credenciales no se pueden rotar** sin coordinar con la DGA y con los titulares de los ocho
pozos, y cinco de ellos comparten la misma contraseña. Mientras esa conversación no ocurra, cortar
la fuente es la única mitigación disponible. Eso es lo que hace este PR.

### Dos fugas que el issue no registraba, y una es peor

Al auditar el resto del código aparecieron dos casos del mismo tipo fuera del servicio de la DGA:

**`validate-params` logueaba `req.body` completo**

Este middleware corre en `POST /users/login` y `POST /users/register`, así que **cada inicio de
sesión escribía la contraseña del usuario sin hashear en los logs**. También corre en la creación y
edición de pozos (`/clients/:id/wells/create`, `/clients/:id/wells/:code/edit`), que llevan las
credenciales DGA en el cuerpo.

Es más grave que lo documentado en el issue: son contraseñas de personas, no de un servicio, y
llegan por el endpoint que más se usa.

**`registerUser` logueaba `userParams` y `req.body`**

Ambos contienen `encrypted_password` cuando todavía es texto plano — el hasheo ocurre después, en el
hook `beforeCreate` del modelo.

## Solución propuesta: eliminar el volcado de objetos, conservar la trazabilidad

El criterio fue distinguir entre logs que servían para trazar y logs que eran depuración olvidada.
Los primeros se reemplazan por una línea que identifica el reporte sin exponer su contenido; los
segundos se eliminan.

**El servicio de envío** (`handleSendData.service.js`)

Se eliminan los tres volcados de objetos y el del XML del método SOAP deprecado, que también incluía
`aut1:password`. En su lugar quedan dos líneas por envío:

```
[dga] enviando reporte 999 | pozo OB-TEST-1 | 2026-08-09 07:00:00
[dga] respuesta reporte 999 | status 00 | sin mensaje
```

La segunda además corrige un error que hacía el log inútil justo durante un incidente: imprimía
`response.data`, que era siempre `undefined` porque `postToDgaV2` ya devuelve `response.data`. Ahora
muestra el `status` y el mensaje reales de la DGA, que es lo que permite distinguir un rechazo por
duplicado de un fallo de credenciales.

**El hook `afterCreate` de `wellData`**

Hacía `console.log(error)` sobre el error crudo. Un error de axios arrastra `config.data`, o sea el
cuerpo enviado con las credenciales dentro. Ahora se loguea sólo el mensaje, junto al reporte y al
pozo que fallaron.

**Los middlewares y el registro de usuarios**

Se eliminan los tres `console.log` de `req.body` y `userParams`. En `registerUser` queda una línea
con el email y el rol, que era la información que realmente se usaba para seguir un registro.

Cada eliminación deja un comentario corto explicando por qué ese objeto no se puede loguear. Sin
eso, el próximo que necesite depurar vuelve a agregar el volcado.

## Lo que este PR no hace

No introduce una función de redacción ni un logger estructurado. Serían mejores a largo plazo, pero
convertirían un cambio verificable en un refactor transversal, y la prioridad ahora es cortar la
fuga. La higiene general de logs está en #72.

Tampoco resuelve la exposición ya ocurrida. Los logs históricos del contenedor siguen conteniendo
las credenciales, y este cambio no los toca. **La rotación sigue pendiente** y es la única acción
que invalida lo que ya salió.

## Cambios tras la revisión

Una revisión independiente confirmó que el PR es puramente de logging: comparando `processAndPostData` entre `master` y esta rama en 8 escenarios (éxito, rechazo, respuesta string/null/undefined, timeout, error con y sin `response`), coinciden en los 8 el valor de retorno, la excepción lanzada y si se llama `wellData.update()`.

De ahí salió un ajuste. La primera versión dejaba el catch del hook `afterCreate` logueando sólo `error.message`, y ese es el camino crítico de ingesta: es justo el log que se necesita durante un incidente. Verificado contra un error de axios real, `error.stack` **no** contiene `config.data`, mientras que `util.inspect(error)` sí lo expande con las credenciales dentro. Se conserva entonces la traza completa sin reabrir la fuga.

Se corrigió también el comentario del hook, que afirmaba que ahí llegan errores de axios. No llegan: `postToDgaV2` los captura antes y devuelve objetos planos. El resguardo se mantiene por si esa cadena cambia, pero dicho con precisión.

## Advertencia: la misma credencial sigue expuesta en un GET público

`GET /fetchUnsentReports` no exige sesión —a propósito, lo consume el SENDER— y su `include` del modelo `Well` no excluye columnas. Un curl sin cabeceras contra producción devuelve 46.754 reportes en 27 MB, cada uno con `password`, `rutEmpresa` y `rutUsuario` poblados.

Este PR cierra la fuga por `docker logs`, que al menos exige acceso a la instancia. Aquella no exige nada. **Mergear esto no reduce la exposición real mientras ese endpoint siga como está**, y se aborda por separado.

## Screenshots

No aplica: no hay cambios visuales.

## Cómo probar

**Verificación automática de que no se filtra nada**

Con axios interceptado antes de cargar el servicio, para no transmitir de verdad al MOP:

```js
const API = '<ruta>/API';
const axios = require(API + '/node_modules/axios');
const bloquear = async (url) => { throw new Error('BLOQUEADO: ' + url); };
axios.post = bloquear;
const createOrig = axios.create.bind(axios);
axios.create = (cfg) => { const c = createOrig(cfg); c.post = bloquear; return c; };
// recién ahora cargar el servicio y llamarlo con un pozo de credenciales falsas
```

Capturando `console.log` durante un `processAndPostData`, ninguna de las credenciales del pozo
aparece en la salida. Verificado en esta rama.

**En local, a mano**

- Iniciar sesión en el portal y confirmar que la contraseña ya no aparece en la salida del servidor.
- Crear o editar un pozo con credenciales DGA y confirmar lo mismo.
- Registrar un usuario: debe verse `[users] registrando <email> con rol <tipo>` y nada más.

**En producción, después de desplegar**

En `sudo docker logs api -f`, confirmar que siguen entrando los `POST /wellData` y que ahora se ve
la línea `[dga] enviando reporte ...` sin credenciales. Es también la señal de que la ingesta de
telemetría sigue viva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
