### PR TITLE
fix: deja de exponer las credenciales DGA en GET /fetchUnsentReports

### DIFF
--- a/API/src/controllers/wellData.controller.js
+++ b/API/src/controllers/wellData.controller.js
@@ -312,6 +312,10 @@ const fetchUnsentReports = async (req, res, next) => {
         {
           model: Well,
           as: "well",
+          // Esta ruta es pública (la consume el SENDER), así que el pozo no
+          // puede viajar con sus credenciales DGA. El join se mantiene porque
+          // el `where` de arriba lo necesita.
+          attributes: { exclude: ["password", "rutEmpresa", "rutUsuario"] },
           where: {
             isActived: true,
             editStatusDate: {

--- a/API/src/controllers/wellData.controller.js
+++ b/API/src/controllers/wellData.controller.js
@@ -221,6 +221,12 @@ const repostAllReportsToDGA = async (req, res, next) => {
                                         [db.Op.in]: reportIds,
                                       },
                                     },
+                                    // OJO: acá el pozo SÍ debe traer sus credenciales DGA, al
+                                    // revés que en fetchUnsentReports. Este `well` se pasa a
+                                    // processAndPostData, que hace parseRUT(data.rutEmpresa), y
+                                    // parseRUT revienta con undefined. Excluirlas "por
+                                    // consistencia" rompe el reenvío manual desde el portal.
+                                    // No se filtran porque esta respuesta no serializa el pozo.
                                     include: [
                                       {
                                         model: Well,


### PR DESCRIPTION
## Issues relacionados

Cierra **#74**. Sin ticket de Jira asociado.

Sólo backend. No toca ningún contrato que use el portal, así que **no aplica la regla de front-primero** del runbook de despliegue.

## Descripción del problema: un GET público devuelve las credenciales de los 8 pozos

`GET /fetchUnsentReports` no exige sesión —es deliberado, la consume el servicio SENDER— y devuelve junto a cada reporte el objeto `Well` completo. Ese objeto incluye `password`, `rutEmpresa` y `rutUsuario`: las credenciales con las que el sistema se autentica ante la DGA en nombre de cada cliente.

Verificado contra producción el 9 de agosto de 2026 con un `curl` sin ninguna cabecera:

```
HTTP 200 | 27.365.946 bytes | 46.754 reportes
campos presentes: password, rutEmpresa, rutUsuario  → los tres poblados
```

No requiere autenticación, ni un token filtrado, ni acceso a la instancia.

Es el mismo hallazgo que el #56 corrigió en `GET /well`. Este endpoint quedó fuera de aquel barrido porque la revisión miró las rutas sin `authMiddleware` una por una, y ésta figuraba como "pública a propósito" — cierto para la ruta, pero nadie revisó qué columnas devolvía el `include`.

**Estas credenciales no se pueden rotar** sin coordinar con la DGA y con los titulares de los ocho pozos, cinco de los cuales comparten la misma contraseña. Cada día de exposición es deuda que no se deshace después.

### Por qué esto importaba más que el #73, que ya está mergeado

El #73 cerró la fuga de las mismas credenciales por `docker logs`, que al menos exige acceso a la instancia EC2. Ésta no exige nada. Mientras este endpoint siguiera como estaba, la exposición real no había bajado: sólo se había cerrado el camino más difícil de los dos.

## Solución propuesta: excluir las columnas, no cerrar la ruta

Cerrar la ruta obligaría a repartir credenciales al SENDER y a desplegarlo. Es un cambio mayor, con un tercero de por medio, y está cubierto por #62. Excluir las columnas resuelve la exposición hoy sin tocar a ningún consumidor.

```js
include: [
  {
    model: Well,
    as: "well",
    attributes: { exclude: ["password", "rutEmpresa", "rutUsuario"] },
    where: { isActived: true, editStatusDate: { [db.Op.ne]: null } },
  },
],
```

El `include` se mantiene porque el `where` lo necesita: filtra por `isActived` y compara `createdAt` contra `well.editStatusDate`. Quitar el join entero rompería la query.

### Ningún consumidor usa esos campos, y está verificado

Revisé los tres antes de tocar nada:

- **SENDER, envío** — `app/models/concerns/send_dga.rb` arma el reenvío como `{ id: report['id'] }`. Nunca lee el objeto `well`.
- **SENDER, validación** — `app/utils/types_format.rb` valida `id`, `sent`, `sentDate`, `code`, `totalizador`, `date` y `hour`, todos campos del reporte. Su `check_type` devuelve `true` para cualquier clave fuera de `STRUCTURE`, así que quitar campos de `well` no altera la validación.
- **Portal** — `WellProjectFront` no referencia `fetchUnsentReports` en ninguna parte.

### Lo que se decidió no hacer

Como ningún consumidor lee `well`, `attributes: []` habría sacado el objeto entero y reducido mucho los 27 MB, que son en buena parte un `well` repetido 46.754 veces.

Se descartó para este PR por criterio de riesgo: cambiar la forma del payload es un cambio de contrato, y la prioridad era cortar la exposición con el menor cambio verificable posible. El tamaño de la respuesta se sigue en **#63**, donde encaja mejor junto al `LIMIT`.

## Screenshots

No aplica: no hay cambios visuales.

## Cómo probar

**Comparación antes/después contra la base local**

Sembrando un reporte que cumpla el `where` dentro de una transacción revertida, y corriendo la query con y sin la exclusión:

```
filas: 1 → 1 ✓ igual
mismos ids: ✓ sí
credenciales ANTES:   password, rutEmpresa, rutUsuario
credenciales DESPUÉS: ninguna
campos del reporte iguales: ✓ sí
campos de `well`: 12 → 9
  quitados:  password, rutEmpresa, rutUsuario
  agregados: ninguno
campos que el SENDER valida (TypesFormat): los 7 presentes
```

La SQL generada confirma que el `INNER JOIN` y el `WHERE` quedan idénticos, y que sólo desaparecen las tres columnas de la lista del `SELECT`.

**Después de desplegar**

```bash
curl -s -o resp.json https://promedicionbackend.com/fetchUnsentReports
node -e 'const s=JSON.stringify(require("./resp.json"));
console.log(["password","rutEmpresa","rutUsuario"].filter(c=>s.includes(`"${c}"`)).join(", ")||"ninguno")'
rm resp.json
```

Debe decir `ninguno`, y el conteo de reportes debe seguir siendo del mismo orden que antes.

Confirmar además que sigue entrando telemetría en `sudo docker logs api -f`, que es la señal de que la ingesta está viva.

## Lo que este PR no resuelve

Las credenciales deben considerarse comprometidas desde una fecha indeterminada. Esto corta la exposición futura; no invalida lo que ya salió. **La rotación sigue pendiente** y es la única acción que lo hace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
