### PR TITLE
fix: hace que la validación de pertenencia efectivamente bloquee (IDOR y checkPermissions sin await)

### DIFF
--- a/API/package.json
+++ b/API/package.json
@@ -4,7 +4,7 @@
   "description": "Proyecto de administración de pozos chilenos y envíos de reportes",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "NODE_ENV=test jest",
     "dev": "nodemon src/server.js"
   },
   "keywords": [],

--- a/API/src/controllers/client.controller.js
+++ b/API/src/controllers/client.controller.js
@@ -67,7 +67,7 @@ const editClient = async (req, res, next) => {
       throw new ErrorHandler(clientHasNoUserOrPersonAssociated);
     }
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
 
@@ -97,7 +97,7 @@ const deleteClient = async (req, res, next) => {
     }
     const user = await client.getUser();
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
 
@@ -118,7 +118,7 @@ const getClientWells = async (req, res, next) => {
       throw new ErrorHandler(clientNotFound);
     }
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
 
@@ -147,7 +147,7 @@ const getOneWell = async (req, res, next) => {
       throw new ErrorHandler(userHasNoClientAssociated);
     }
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
 
@@ -203,7 +203,7 @@ const editClientWell = async (req, res, next) => {
       throw new ErrorHandler(userHasNoClientAssociated);
     }
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
 
@@ -282,7 +282,7 @@ const deleteClientWell = async (req, res, next) => {
       throw new ErrorHandler(userHasNoClientAssociated);
     }
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
 
@@ -317,7 +317,7 @@ const getWellData = async (req, res, next) => {
       throw new ErrorHandler(clientNotFound);
     }
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
     const well = await Well.findOne({ where: { code: wellCode, clientId: client.id } });
@@ -384,7 +384,7 @@ const createClientWell = async (req, res, next) => {
       throw new ErrorHandler(clientNotFound);
     }
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
 

--- a/API/src/controllers/company.controller.js
+++ b/API/src/controllers/company.controller.js
@@ -196,7 +196,7 @@ const editCompany = async (req, res, next) => {
       throw new ErrorHandler(clientHasNoUserOrPersonAssociated);
     }
 
-    if (!checkPermissionsForClientResources(req.user, company)) {
+    if (!await checkPermissionsForClientResources(req.user, company)) {
       throw new ErrorHandler(unauthorized);
     }
 

--- a/API/src/controllers/company.controller.js
+++ b/API/src/controllers/company.controller.js
@@ -1,7 +1,7 @@
 const db = require('../../models');
 const ErrorHandler = require('../utils/error.util');
 const checkPermissionsForClientResources = require('../utils/check-permissions');
-const { companyNotFound, clientNotFound, clientDoesntBelongToCompany, clientHasNoUserOrPersonAssociated } = require('../utils/errorcodes.util');
+const { companyNotFound, clientNotFound, clientDoesntBelongToCompany, clientHasNoUserOrPersonAssociated, unauthorized } = require('../utils/errorcodes.util');
 
 const Company = db.company;
 const User = db.user;

--- a/API/src/controllers/distributor.controller.js
+++ b/API/src/controllers/distributor.controller.js
@@ -6,6 +6,7 @@ const {
   distributorNotFound,
   companyDoesntBelongToDistributor,
   distributorHasNoUserOrPersonAssociated,
+  unauthorized,
 } = require("../utils/errorcodes.util");
 
 const Company = db.company;

--- a/API/src/controllers/distributor.controller.js
+++ b/API/src/controllers/distributor.controller.js
@@ -187,7 +187,7 @@ const editDistributor = async (req, res, next) => {
       throw new ErrorHandler(distributorHasNoUserOrPersonAssociated);
     }
 
-    if (!checkPermissionsForClientResources(req.user, distributor)) {
+    if (!await checkPermissionsForClientResources(req.user, distributor)) {
       throw new ErrorHandler(unauthorized);
     }
 

--- a/API/src/controllers/user.controller.js
+++ b/API/src/controllers/user.controller.js
@@ -22,11 +22,15 @@ const Role = db.role;
 // puede resolverlo: cuando se registra a alguien todavía no existe la entidad
 // contra la cual comparar pertenencia, así que lo que se valida es qué rol se
 // está creando y bajo qué empresa o distribuidora queda colgando.
+// Devuelve la empresa bajo la cual debe quedar el cliente cuando el body no la
+// trae. Sin eso, una empresa que da de alta un cliente desde la vista general
+// del portal —donde `companyId` viaja como null— crearía un cliente huérfano y
+// perdería el acceso al cliente que acaba de crear.
 const assertCanCreateUserWithRole = async (requester, targetRole, body, transaction) => {
   const { id: requesterId, type: requesterRole } = requester;
 
   if (requesterRole === 'admin') {
-    return;
+    return { companyIdPorDefecto: null };
   }
 
   // Nadie que no sea admin puede fabricar un admin. Es el escalamiento directo.
@@ -46,7 +50,7 @@ const assertCanCreateUserWithRole = async (requester, targetRole, body, transact
     if (body.companyId && parseInt(body.companyId, 10) !== own.id) {
       throw new ErrorHandler(unauthorized);
     }
-    return;
+    return { companyIdPorDefecto: own.id };
   }
 
   if (requesterRole === 'distributor') {
@@ -59,17 +63,19 @@ const assertCanCreateUserWithRole = async (requester, targetRole, body, transact
       if (body.distributorId && parseInt(body.distributorId, 10) !== own.id) {
         throw new ErrorHandler(unauthorized);
       }
-      return;
+      return { companyIdPorDefecto: null };
     }
     if (targetRole === 'normal') {
+      // Una distribuidora no tiene una empresa "propia" evidente, así que si no
+      // indica cuál, el cliente queda sin empresa igual que antes.
       if (!body.companyId) {
-        return;
+        return { companyIdPorDefecto: null };
       }
       const target = await Company.findByPk(parseInt(body.companyId, 10), { transaction });
       if (!target || target.distributorId !== own.id) {
         throw new ErrorHandler(unauthorized);
       }
-      return;
+      return { companyIdPorDefecto: null };
     }
   }
 
@@ -222,7 +228,9 @@ const registerUser = async (req, res, next) => {
     // que el control es sobre el destino: a quién se está creando y bajo quién
     // queda colgando. Sin esto, una empresa podría crearse un admin o meter un
     // cliente bajo otra empresa.
-    await assertCanCreateUserWithRole(req.user, role.type, req.body, transaction);
+    const { companyIdPorDefecto } = await assertCanCreateUserWithRole(
+      req.user, role.type, req.body, transaction
+    );
 
     const user = await User.create(userParams, {
       transaction,
@@ -237,6 +245,9 @@ const registerUser = async (req, res, next) => {
       const clientParams = { userId: user.id };
       if (req.body.companyId) {
         clientParams.companyId = parseInt(req.body.companyId, 10);
+      } else if (companyIdPorDefecto) {
+        // El portal manda `companyId: null` al crear desde la vista general.
+        clientParams.companyId = companyIdPorDefecto;
       }
 
       createdClient = await Client.create(clientParams, { transaction });

--- a/API/src/controllers/user.controller.js
+++ b/API/src/controllers/user.controller.js
@@ -18,6 +18,64 @@ const Company = db.company;
 const Distributor = db.distributor;
 const Role = db.role;
 
+// Control de destino para las creaciones de usuario. `checkPermissions` no
+// puede resolverlo: cuando se registra a alguien todavía no existe la entidad
+// contra la cual comparar pertenencia, así que lo que se valida es qué rol se
+// está creando y bajo qué empresa o distribuidora queda colgando.
+const assertCanCreateUserWithRole = async (requester, targetRole, body, transaction) => {
+  const { id: requesterId, type: requesterRole } = requester;
+
+  if (requesterRole === 'admin') {
+    return;
+  }
+
+  // Nadie que no sea admin puede fabricar un admin. Es el escalamiento directo.
+  if (targetRole === 'admin') {
+    throw new ErrorHandler(unauthorized);
+  }
+
+  if (requesterRole === 'company') {
+    // Una empresa sólo da de alta a sus propios clientes.
+    if (targetRole !== 'normal') {
+      throw new ErrorHandler(unauthorized);
+    }
+    const own = await Company.findOne({ where: { userId: requesterId }, transaction });
+    if (!own) {
+      throw new ErrorHandler(unauthorized);
+    }
+    if (body.companyId && parseInt(body.companyId, 10) !== own.id) {
+      throw new ErrorHandler(unauthorized);
+    }
+    return;
+  }
+
+  if (requesterRole === 'distributor') {
+    const own = await Distributor.findOne({ where: { userId: requesterId }, transaction });
+    if (!own) {
+      throw new ErrorHandler(unauthorized);
+    }
+    // Sus empresas, y los clientes que cuelguen de esas empresas.
+    if (targetRole === 'company') {
+      if (body.distributorId && parseInt(body.distributorId, 10) !== own.id) {
+        throw new ErrorHandler(unauthorized);
+      }
+      return;
+    }
+    if (targetRole === 'normal') {
+      if (!body.companyId) {
+        return;
+      }
+      const target = await Company.findByPk(parseInt(body.companyId, 10), { transaction });
+      if (!target || target.distributorId !== own.id) {
+        throw new ErrorHandler(unauthorized);
+      }
+      return;
+    }
+  }
+
+  throw new ErrorHandler(unauthorized);
+};
+
 //           GET USER DATA
 
 const getUsers = async (req, res, next) => {
@@ -93,7 +151,7 @@ const getUserInfoById = async (req, res, next) => {
     const client = await Client.findByPk(clientId);
     const userId = client.userId;
 
-    if (!checkPermissionsForClientResources(req.user, client)) {
+    if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
 
@@ -138,7 +196,7 @@ const registerUser = async (req, res, next) => {
 
   try {
     const { id: requesterId, type: requesterRole } = req.user;
-    if (!checkPermissionsForClientResources(req.user, undefined, true)) {
+    if (!await checkPermissionsForClientResources(req.user, undefined, true)) {
       throw new ErrorHandler(unauthorized);
     }
     delete req.body.id;
@@ -159,6 +217,12 @@ const registerUser = async (req, res, next) => {
     if (!role) {
       throw new ErrorHandler(userNotFound);
     }
+
+    // En una creación no hay entidad contra la cual comprobar pertenencia, así
+    // que el control es sobre el destino: a quién se está creando y bajo quién
+    // queda colgando. Sin esto, una empresa podría crearse un admin o meter un
+    // cliente bajo otra empresa.
+    await assertCanCreateUserWithRole(req.user, role.type, req.body, transaction);
 
     const user = await User.create(userParams, {
       transaction,

--- a/API/src/controllers/well.controller.js
+++ b/API/src/controllers/well.controller.js
@@ -60,7 +60,7 @@ const getWellDataByWell = async (req, res) => {
   }
 }
 
-const activeOrDesactiveWell = async (req, res) => {
+const activeOrDesactiveWell = async (req, res, next) => {
   try {
     // Get well with full context for activity logging
     const well = await Well.findOne({
@@ -108,7 +108,10 @@ const activeOrDesactiveWell = async (req, res) => {
       });
     }
 
-    if (!checkPermissionsForClientResources(req.user, undefined, true)) {
+    // Se valida contra el cliente dueño del pozo, no contra `undefined`. Antes
+    // no se comprobaba pertenencia alguna, así que cualquier usuario podía
+    // desactivar el pozo de otro cliente y cortarle el reporte a la DGA.
+    if (!await checkPermissionsForClientResources(req.user, well.client)) {
       throw new ErrorHandler(unauthorized);
     }
 
@@ -160,9 +163,11 @@ const activeOrDesactiveWell = async (req, res) => {
 
     res.json(well);
   } catch (error) {
-    res.status(500).send({
-      message: error.message || 'Some error occurred while activating the Well'
-    });
+    // Se delega en el middleware de errores para que un fallo de autorización
+    // salga como 401 y no como 500. Antes todo caía en el mismo `catch` y el
+    // portal no podía distinguir "este pozo no es tuyo" de "el servidor se
+    // cayó".
+    next(error);
   }
 }
 

--- a/API/src/controllers/wellData.controller.js
+++ b/API/src/controllers/wellData.controller.js
@@ -2,11 +2,29 @@ const db = require("../../models");
 
 const Well = db.well;
 const WellData = db.wellData;
+const Client = db.client;
 
 const processAndPostData = require("../services/wellData/handleSendData.service");
 const ErrorHandler = require("../utils/error.util");
+const checkPermissionsForClientResources = require("../utils/check-permissions");
 const moment = require("moment-timezone");
-const { bulkCreateWellDataIsNotArray } = require("../utils/errorcodes.util");
+const { bulkCreateWellDataIsNotArray, unauthorized } = require("../utils/errorcodes.util");
+
+// Comprueba que el solicitante pueda operar sobre todos los reportes de la
+// tanda. Se exige el lote completo en vez de filtrar los ajenos en silencio:
+// si la petición trae algo que no le corresponde, es un error de quien llama,
+// y borrar o transmitir "sólo una parte" es peor que rechazar.
+const assertOwnsReports = async (requester, reports) => {
+  for (const report of reports) {
+    const permitido = await checkPermissionsForClientResources(
+      requester,
+      report.well?.client
+    );
+    if (!permitido) {
+      throw new ErrorHandler(unauthorized);
+    }
+  }
+};
 
 /**
  * Normaliza un valor numérico que puede venir con coma como separador decimal
@@ -231,6 +249,7 @@ const repostAllReportsToDGA = async (req, res, next) => {
                                       {
                                         model: Well,
                                         as: 'well',
+                                        include: [{ model: Client, as: 'client' }],
                                       },
                                     ],
                                   });
@@ -242,6 +261,10 @@ const repostAllReportsToDGA = async (req, res, next) => {
         message: "No se encontraron reportes para enviar.",
       });
     }
+
+    // Mismo IDOR que en el borrado masivo: sin esto, cualquiera puede forzar el
+    // envío a la DGA de reportes de otro cliente enumerando ids.
+    await assertOwnsReports(req.user, reports);
 
     // Procesar los reportes en paralelo con concurrencia limitada
     const concurrencyLimit = 3; // Limitar la cantidad de envíos simultáneos
@@ -361,10 +384,26 @@ const bulkDeleteWellData = async (req, res, next) => {
       });
     }
 
+    // Los ids de reporte son autoincrementales, así que sin comprobar
+    // pertenencia basta con enumerar para borrar telemetría de cualquier
+    // cliente. Se resuelve el dueño de cada reporte antes de tocar nada.
+    const objetivos = await WellData.findAll({
+      where: { id: { [db.Op.in]: reportIds } },
+      include: [{ model: Well, as: "well", include: [{ model: Client, as: "client" }] }],
+    });
+
+    if (objetivos.length === 0) {
+      return res.status(404).send({
+        message: "No se encontraron reportes con los IDs proporcionados.",
+      });
+    }
+
+    await assertOwnsReports(req.user, objetivos);
+
     const deletedCount = await WellData.destroy({
       where: {
         id: {
-          [db.Op.in]: reportIds,
+          [db.Op.in]: objetivos.map((r) => r.id),
         },
       },
     });

--- a/API/src/controllers/wellData.controller.js
+++ b/API/src/controllers/wellData.controller.js
@@ -15,12 +15,23 @@ const { bulkCreateWellDataIsNotArray, unauthorized } = require("../utils/errorco
 // si la petición trae algo que no le corresponde, es un error de quien llama,
 // y borrar o transmitir "sólo una parte" es peor que rechazar.
 const assertOwnsReports = async (requester, reports) => {
+  // Se comprueba una vez por cliente distinto, no una vez por reporte:
+  // checkPermissions consulta la base, y un lote de miles de reportes casi
+  // siempre pertenece a uno o dos clientes.
+  const porCliente = new Map();
   for (const report of reports) {
-    const permitido = await checkPermissionsForClientResources(
-      requester,
-      report.well?.client
-    );
-    if (!permitido) {
+    const cliente = report.well?.client;
+    // Sin cliente resoluble no se puede afirmar pertenencia: se niega.
+    if (!cliente) {
+      throw new ErrorHandler(unauthorized);
+    }
+    if (!porCliente.has(cliente.id)) {
+      porCliente.set(cliente.id, cliente);
+    }
+  }
+
+  for (const cliente of porCliente.values()) {
+    if (!await checkPermissionsForClientResources(requester, cliente)) {
       throw new ErrorHandler(unauthorized);
     }
   }

--- a/API/src/utils/check-permissions.js
+++ b/API/src/utils/check-permissions.js
@@ -2,35 +2,73 @@ const db = require('../../models');
 const Company = db.company;
 const Distributor = db.distributor;
 
-// Funcion que permite a un admin acceder a cualquier recurso
-// a un company acceder a los recursos que el mismo creo
-// y a un normal acceder a los recursos que le pertenecen || OJO con esto deberia solo servir para algunos casos, como getUserInfoById
-const checkPermissionsForClientResources = async (user, entity)=> {
+// Verifica que el solicitante pueda operar sobre `entity`, siguiendo la
+// jerarquía distribuidora → empresa → cliente → pozo.
+//
+//   admin        cualquier recurso.
+//   dueño        cualquier rol sobre su propio registro (`entity.userId`).
+//                Es lo que permite que una empresa edite sus propios datos.
+//   company      los clientes que cuelgan de su empresa.
+//   distributor  sus empresas, y los clientes de esas empresas.
+//
+// `isCreation` es para operaciones que todavía no tienen entidad, como registrar
+// un usuario. Ahí no hay pertenencia que comprobar: el authMiddleware de la ruta
+// ya filtró por rol, y validar el destino le corresponde al controlador.
+//
+// ⚠️ Es `async`. Llamarla sin `await` devuelve una Promise, que siempre es
+// truthy, así que `!checkPermissions(...)` nunca se cumple y la validación no
+// bloquea nada. Fue el bug del issue #60: parecía validar y no validaba.
+const checkPermissionsForClientResources = async (user, entity, isCreation = false) => {
     const { id: requesterId, type: requesterRole } = user;
 
     if (requesterRole === 'admin') {
         return true;
     }
 
-    if (requesterRole === 'company'){
-        const company = await Company.findOne({ where: {userId: requesterId} })
-        if (entity?.createdBy === requesterId || entity?.companyId === company.id) {
-            return true;
-        }
-    }
-
-    if (requesterRole === 'distributor') {
-        const distributor = await Distributor.findOne({ where: {userId: requesterId} })
-        if (entity?.createdBy === requesterId || entity?.distributorId === distributor.id) {
-            return true;
-        }
-    }
-
-    if (requesterRole === 'normal' && entity?.userId === requesterId) {
+    if (isCreation) {
         return true;
     }
 
-    return false
+    // Sin entidad no hay pertenencia que verificar, así que se niega. Sólo las
+    // creaciones pueden llegar acá sin entidad, y ésas ya salieron arriba.
+    if (!entity) {
+        return false;
+    }
+
+    if (entity.userId === requesterId) {
+        return true;
+    }
+
+    if (requesterRole === 'company') {
+        const company = await Company.findOne({ where: { userId: requesterId } });
+        // Un usuario con rol company pero sin fila en `companies` no gestiona
+        // a nadie. Antes esto reventaba con TypeError al leer `company.id`.
+        if (!company) {
+            return false;
+        }
+        return entity.companyId === company.id;
+    }
+
+    if (requesterRole === 'distributor') {
+        const distributor = await Distributor.findOne({ where: { userId: requesterId } });
+        if (!distributor) {
+            return false;
+        }
+
+        // Sus empresas.
+        if (entity.distributorId === distributor.id) {
+            return true;
+        }
+
+        // Los clientes de sus empresas: hay que subir un nivel para saber de
+        // qué distribuidora cuelga la empresa del cliente.
+        if (entity.companyId) {
+            const company = await Company.findByPk(entity.companyId);
+            return !!company && company.distributorId === distributor.id;
+        }
+    }
+
+    return false;
 }
 
 module.exports = checkPermissionsForClientResources;

--- a/API/tests/helpers/safe-database.js
+++ b/API/tests/helpers/safe-database.js
@@ -1,0 +1,52 @@
+// Guard para los tests que destruyen datos.
+//
+// `sequelize.sync({ force: true })` elimina y recrea todas las tablas de la
+// base a la que esté apuntando la conexión. Qué base es eso lo decide
+// `models/index.js` con `process.env.NODE_ENV || 'development'`, y el `.env`
+// del proyecto fija `NODE_ENV=development`. Sin este guard, un `npx jest` sin
+// filtro vacía la base de desarrollo, y dentro de la instancia vaciaría la de
+// producción.
+//
+// La regla es que borrar sólo se permite cuando las dos condiciones se cumplen:
+// el entorno es `test`, y el nombre de la base termina en `_test`. Se exigen
+// las dos a propósito: la primera se puede sobreescribir por accidente desde el
+// shell, y la segunda es la que de verdad protege la base equivocada.
+
+const { sequelize } = require('../../models');
+
+const assertSafeToWipe = () => {
+  const base = sequelize.config.database;
+  const host = sequelize.config.host;
+  const entorno = process.env.NODE_ENV;
+
+  const problemas = [];
+  if (entorno !== 'test') {
+    problemas.push(`NODE_ENV es "${entorno}" y tiene que ser "test"`);
+  }
+  if (!/_test$/.test(base || '')) {
+    problemas.push(`la base es "${base}" y su nombre tiene que terminar en "_test"`);
+  }
+
+  if (problemas.length > 0) {
+    throw new Error(
+      [
+        '',
+        '⛔ Test destructivo detenido: iba a borrar todas las tablas de una base que no es de pruebas.',
+        '',
+        `   destino:  ${base}@${host}`,
+        ...problemas.map((p) => `   problema: ${p}`),
+        '',
+        '   Para correr los tests que tocan la base:',
+        '     createdb wellproject_dev_test',
+        '     npm test',
+        '',
+        '   `npm test` ya fija NODE_ENV=test. Si lo sobreescribiste a mano, quítalo.',
+        '',
+      ].join('\n')
+    );
+  }
+
+  return { base, host };
+};
+
+module.exports = { assertSafeToWipe };

--- a/API/tests/models/user.test.js
+++ b/API/tests/models/user.test.js
@@ -1,9 +1,13 @@
 // user.test.js
 
 const { sequelize } = require('../../models');
+const { assertSafeToWipe } = require('../helpers/safe-database');
 
 describe('User model', () => {
   beforeAll(async () => {
+    // `sync({ force: true })` borra todas las tablas: se comprueba primero que
+    // la conexión apunte a una base de pruebas y no a desarrollo o producción.
+    assertSafeToWipe();
     await sequelize.sync({ force: true });
   });
 

--- a/API/tests/utils/check-permissions.test.js
+++ b/API/tests/utils/check-permissions.test.js
@@ -1,0 +1,124 @@
+// check-permissions.test.js
+//
+// Test unitario, sin base de datos: los modelos van mockeados. Es deliberado.
+// El resto de la suite hace `sequelize.sync({ force: true })` y, como
+// `NODE_ENV` es `development`, apunta a la base de desarrollo. Este archivo no
+// depende de esa configuración y se puede correr en cualquier parte.
+
+const mockCompanyFindOne = jest.fn();
+const mockCompanyFindByPk = jest.fn();
+const mockDistributorFindOne = jest.fn();
+
+jest.mock('../../models', () => ({
+  company: { findOne: (...a) => mockCompanyFindOne(...a), findByPk: (...a) => mockCompanyFindByPk(...a) },
+  distributor: { findOne: (...a) => mockDistributorFindOne(...a) },
+}));
+
+const checkPermissions = require('../../src/utils/check-permissions');
+
+const ADMIN = { id: 1, type: 'admin' };
+const EMPRESA = { id: 4, type: 'company' };
+const DISTRIBUIDORA = { id: 10, type: 'distributor' };
+const NORMAL = { id: 5, type: 'normal' };
+
+// Entidades: sólo importan los campos que la función lee.
+const clientePropio = { userId: 5, companyId: 1 };
+const clienteDeOtraEmpresa = { userId: 99, companyId: 2 };
+const empresaPropia = { userId: 4, distributorId: 10 };
+const empresaAjena = { userId: 77, distributorId: 20 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCompanyFindOne.mockResolvedValue({ id: 1 });
+  mockDistributorFindOne.mockResolvedValue({ id: 10 });
+  mockCompanyFindByPk.mockResolvedValue({ id: 1, distributorId: 10 });
+});
+
+describe('checkPermissionsForClientResources', () => {
+  it('es async: sin await el resultado es una Promise siempre truthy', () => {
+    // Guarda contra la regresión del #60. Si alguien la vuelve síncrona o
+    // alguien la llama sin await, `!resultado` nunca se cumple.
+    const resultado = checkPermissions(NORMAL, clienteDeOtraEmpresa);
+    expect(resultado).toBeInstanceOf(Promise);
+    expect(!resultado).toBe(false);
+  });
+
+  describe('admin', () => {
+    it('accede a cualquier entidad', async () => {
+      await expect(checkPermissions(ADMIN, clienteDeOtraEmpresa)).resolves.toBe(true);
+      await expect(checkPermissions(ADMIN, empresaAjena)).resolves.toBe(true);
+    });
+  });
+
+  describe('normal', () => {
+    it('accede a su propio registro', async () => {
+      await expect(checkPermissions(NORMAL, clientePropio)).resolves.toBe(true);
+    });
+
+    it('no accede al registro de otro cliente', async () => {
+      await expect(checkPermissions(NORMAL, clienteDeOtraEmpresa)).resolves.toBe(false);
+    });
+
+    it('no accede a una empresa', async () => {
+      await expect(checkPermissions(NORMAL, empresaPropia)).resolves.toBe(false);
+    });
+  });
+
+  describe('company', () => {
+    it('accede a los clientes de su empresa', async () => {
+      await expect(checkPermissions(EMPRESA, clientePropio)).resolves.toBe(true);
+    });
+
+    it('no accede a clientes de otra empresa', async () => {
+      await expect(checkPermissions(EMPRESA, clienteDeOtraEmpresa)).resolves.toBe(false);
+    });
+
+    it('accede a sus propios datos de empresa', async () => {
+      await expect(checkPermissions(EMPRESA, empresaPropia)).resolves.toBe(true);
+    });
+
+    it('devuelve false, sin reventar, si no tiene fila en companies', async () => {
+      // Antes leía `company.id` sobre null y lanzaba TypeError, que el
+      // middleware de errores convertía en 500 en vez de 401.
+      mockCompanyFindOne.mockResolvedValue(null);
+      await expect(checkPermissions(EMPRESA, clientePropio)).resolves.toBe(false);
+    });
+  });
+
+  describe('distributor', () => {
+    it('accede a las empresas que cuelgan de ella', async () => {
+      await expect(checkPermissions(DISTRIBUIDORA, empresaPropia)).resolves.toBe(true);
+    });
+
+    it('no accede a empresas de otra distribuidora', async () => {
+      await expect(checkPermissions(DISTRIBUIDORA, empresaAjena)).resolves.toBe(false);
+    });
+
+    it('accede a los clientes de sus empresas', async () => {
+      await expect(checkPermissions(DISTRIBUIDORA, clientePropio)).resolves.toBe(true);
+      expect(mockCompanyFindByPk).toHaveBeenCalledWith(1);
+    });
+
+    it('no accede a clientes de empresas ajenas', async () => {
+      mockCompanyFindByPk.mockResolvedValue({ id: 2, distributorId: 20 });
+      await expect(checkPermissions(DISTRIBUIDORA, clienteDeOtraEmpresa)).resolves.toBe(false);
+    });
+
+    it('devuelve false, sin reventar, si no tiene fila en distributors', async () => {
+      mockDistributorFindOne.mockResolvedValue(null);
+      await expect(checkPermissions(DISTRIBUIDORA, empresaPropia)).resolves.toBe(false);
+    });
+  });
+
+  describe('creaciones y entidades ausentes', () => {
+    it('deja pasar una creación: el authMiddleware de la ruta ya filtró por rol', async () => {
+      await expect(checkPermissions(EMPRESA, undefined, true)).resolves.toBe(true);
+    });
+
+    it('niega si no hay entidad y no es una creación', async () => {
+      // Es el caso que antes se colaba: `undefined` con la llamada sin await.
+      await expect(checkPermissions(EMPRESA, undefined)).resolves.toBe(false);
+      await expect(checkPermissions(EMPRESA, null)).resolves.toBe(false);
+    });
+  });
+});

--- a/API/tests/utils/check-permissions.test.js
+++ b/API/tests/utils/check-permissions.test.js
@@ -120,5 +120,65 @@ describe('checkPermissionsForClientResources', () => {
       await expect(checkPermissions(EMPRESA, undefined)).resolves.toBe(false);
       await expect(checkPermissions(EMPRESA, null)).resolves.toBe(false);
     });
+
+    it('isCreation cortocircuita aunque se pase una entidad ajena', async () => {
+      // Comportamiento deliberado y peligroso si se usa mal: `isCreation` va
+      // antes que cualquier comprobación de pertenencia. Sólo debe pasarse en
+      // altas reales, donde todavía no hay entidad.
+      await expect(checkPermissions(EMPRESA, clienteDeOtraEmpresa, true)).resolves.toBe(true);
+    });
+  });
+
+  describe('casos que rompen la cadena de la jerarquía', () => {
+    it('distribuidora no accede a un cliente sin empresa', async () => {
+      // Un cliente sin `companyId` no cuelga de ninguna distribuidora.
+      await expect(checkPermissions(DISTRIBUIDORA, { userId: 99, companyId: null })).resolves.toBe(false);
+    });
+
+    it('distribuidora no accede si la empresa del cliente no existe', async () => {
+      mockCompanyFindByPk.mockResolvedValue(null);
+      await expect(checkPermissions(DISTRIBUIDORA, clientePropio)).resolves.toBe(false);
+    });
+
+    it('ser dueño tiene precedencia sobre las ramas de rol', async () => {
+      // Aunque la empresa del solicitante no coincida, el registro es suyo.
+      mockCompanyFindOne.mockResolvedValue({ id: 999 });
+      await expect(checkPermissions(EMPRESA, { userId: 4, companyId: 1 })).resolves.toBe(true);
+      expect(mockCompanyFindOne).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('los llamadores no pueden olvidar el await', () => {
+  // El test de arriba sólo comprueba que la función devuelve una Promise. Esto
+  // es lo que de verdad guarda contra la regresión del #60: si alguien agrega
+  // una llamada sin `await`, la validación vuelve a no bloquear nada y no hay
+  // ningún síntoma visible.
+  const fs = require('fs');
+  const path = require('path');
+
+  const archivosJs = (dir) =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+      const p = path.join(dir, e.name);
+      return e.isDirectory() ? archivosJs(p) : p.endsWith('.js') ? [p] : [];
+    });
+
+  it('todas las invocaciones en src/ llevan await', () => {
+    const raiz = path.join(__dirname, '..', '..', 'src');
+    const sinAwait = [];
+
+    for (const archivo of archivosJs(raiz)) {
+      const lineas = fs.readFileSync(archivo, 'utf8').split('\n');
+      lineas.forEach((linea, i) => {
+        // Se ignoran el require y la definición de la propia función.
+        if (!linea.includes('checkPermissionsForClientResources(')) return;
+        if (linea.includes('require(') || linea.includes('=')) return;
+        if (!linea.includes('await checkPermissionsForClientResources(')) {
+          sinAwait.push(`${path.relative(raiz, archivo)}:${i + 1}`);
+        }
+      });
+    }
+
+    expect(sinAwait).toEqual([]);
   });
 });


### PR DESCRIPTION
## Issues relacionados

Cierra **#59** y **#60**. Sin ticket de Jira asociado.

Van juntos porque comparten la misma función y el segundo explica por qué el primero existía.

**Este PR sí puede requerir desplegar el portal antes.** A diferencia de los anteriores, cambia quién recibe 401. Ver "Impacto en el portal" al final.

## Descripción del problema: la autorización por pertenencia nunca bloqueó nada

`checkPermissionsForClientResources` es `async`, y se llamaba **sin `await` en los 13 sitios donde se usa**. `!promise` es siempre `false`, así que la condición nunca se cumplía. El código parecía validar permisos y no validaba ninguno.

Lo único que protegía de verdad era el `authMiddleware`, que filtra por rol pero no por pertenencia. En la práctica: cualquier usuario autenticado podía operar sobre recursos de cualquier otro cliente.

Las dos consecuencias con issue propio:

- **#60** — `PUT /wells/:id/active`: cualquiera podía desactivar el pozo de otro cliente, y desactivar un pozo le corta el reporte a la DGA.
- **#59** — `DELETE /wellData/bulk` y `POST /repostAllReportsToDGA`: los ids de reporte son autoincrementales, así que borrar telemetría ajena o forzar envíos al regulador no requería adivinar nada.

### Por qué no bastaba con agregar el `await`

Ésta es la parte que no estaba en los issues, y es la que define el tamaño del PR. Con la función tal como estaba, activarla habría roto el sistema. Medido contra la base local:

| operación | quién podía antes | quién podría con sólo agregar `await` |
|---|---|---|
| activar/desactivar un pozo | admin, company, normal | **sólo admin** |
| registrar usuarios | admin, company, distributor | **sólo admin** |
| una empresa edita sus propios datos | sí | **no** |
| una distribuidora edita los suyos | sí | **no** |

Además reventaba con `TypeError: Cannot read properties of null (reading 'id')` cuando el solicitante tenía rol `company` o `distributor` pero no tenía fila en su tabla.

Y la mitad de la lógica era código muerto: comparaba `entity.createdBy`, pero **`createdBy` sólo existe en el modelo `user`**, y a la función se le pasa siempre un `client`, un `company` o un `distributor`. Esa rama no podía cumplirse nunca.

## Solución propuesta: reescribir la función y después activarla

La jerarquía queda explícita, siguiendo distribuidora → empresa → cliente → pozo:

- **admin**: cualquier recurso.
- **dueño**: cualquier rol sobre su propio registro (`entity.userId`). Es lo que permite que una empresa edite sus propios datos.
- **company**: los clientes que cuelgan de su empresa.
- **distributor**: sus empresas, y los clientes de esas empresas.

El tercer parámetro `isCreation` pasa a existir de verdad. Dos llamadas ya lo pasaban como `true`, pero la firma sólo aceptaba dos argumentos, así que se ignoraba en silencio.

### Decisiones que se tomaron y por qué

**La distribuidora baja hasta clientes y pozos.** Podía haberse quedado sólo en el nivel de empresas, que era más simple. Se eligió bajar porque es coherente con la jerarquía. Cuesta una consulta extra para resolver la cadena cliente → empresa → distribuidora.

> **Corrección:** una primera versión de esta descripción decía que esto resolvía el issue **#43** del front. Es falso, y la revisión lo desmintió. Todas las rutas `/clients/*` están montadas con `AdminAndCompanyAndNormal`, así que el `authMiddleware` rechaza a `distributor` **antes** de que `checkPermissions` llegue a correr. El descenso que agrega este PR hoy sólo es alcanzable desde `GET /users/data/:id`, que sí admite todos los roles. Para entregar el #43 hay que además agregar `distributor` a esas rutas, y eso queda fuera de este PR.

**En las creaciones se valida el destino, no la pertenencia.** Cuando se registra un usuario todavía no hay entidad contra la cual comparar, así que `checkPermissions` deja pasar y el control se hace en el controlador: nadie que no sea admin puede crear un admin, una empresa sólo da de alta clientes bajo sí misma, y una distribuidora sólo bajo sus empresas. La alternativa —restringir toda creación a admin— habría roto que las empresas registren a sus propios clientes, que es un flujo en uso.

**En los endpoints masivos se exige el lote completo.** Si la petición trae un reporte ajeno, se rechaza entera en vez de filtrar los ajenos en silencio. Borrar o transmitir "sólo una parte" sin avisar es peor que negar.

### Un arreglo que el fix necesitaba

`activeOrDesactiveWell` tenía un `catch` que devolvía 500 para todo, así que el 401 de autorización salía como error de servidor. Se delega en `next(error)`, como el resto de los controladores. Sin esto el #60 quedaba "arreglado" pero el portal no podía distinguir "este pozo no es tuyo" de "el servidor se cayó".

## Screenshots

No aplica: no hay cambios visuales.

## Cómo probar

**Test unitario incorporado**

Se agrega `tests/utils/check-permissions.test.js`, con 21 casos que cubren los cuatro roles, los cruces ajenos, los casos de fila faltante, las creaciones y las roturas de la cadena jerárquica. Incluye un guardián que recorre `src/` y falla si alguna invocación pierde el `await`.

```
npx jest tests/utils/check-permissions.test.js
Tests: 21 passed, 21 total
```

Va con los modelos mockeados y sin base de datos, a propósito: no depende de que exista una base de pruebas ni de cómo esté `NODE_ENV`.

**Verificación end-to-end contra la base local**

Levantando el servidor con axios bloqueado y JWT reales por rol, 19 comprobaciones sobre los endpoints:

```
PUT /wells/4/active  (pozo del client 3: user 5, empresa 1)
  ✓ dueño (normal u5) → 200        ✓ OTRO cliente (u2) — el IDOR del #60 → 401
  ✓ su empresa (u4)   → 200        ✓ OTRA empresa (u7) → 401
  ✓ admin             → 200        ✓ sin token → 401
DELETE /wellData/bulk
  ✓ cliente ajeno (u5) — el IDOR del #59 → 401     ✓ otra empresa (u4) → 401
POST /repostAllReportsToDGA
  ✓ cliente ajeno (u5) → 401
POST /users/register
  ✓ empresa1 crea admin → 401      ✓ empresa1 crea cliente en OTRA empresa → 401
  ✓ empresa1 crea cliente propio → 200
GET /clients/3/wells
  ✓ su empresa (u4) → 200          ✓ otra empresa (u7) → 401
PUT /companies/:id/edit
  ✓ empresa1 edita la empresa 2 → 401, no 500      ✓ empresa1 edita la suya → 200
  ✓ la empresa 2 quedó sin tocar
DELETE /wellData/bulk — lote mixto
  ✓ propio + ajeno → 401           ✓ no se borró nada
```

La base local quedó intacta: el pozo tocado se restauró a su estado previo y el usuario de prueba se eliminó.

**En el portal, a mano**

Los flujos que cambian de comportamiento y conviene ejercitar con cada rol:

- Activar y desactivar un pozo, como cliente y como empresa.
- Que una empresa registre un cliente nuevo.
- Que una empresa edite sus propios datos.
- Seleccionar reportes y borrarlos, y enviarlos a la DGA.

## Impacto en el portal: esto sí cambia quién recibe 401

Hasta ahora ningún usuario era bloqueado por pertenencia. Desde este PR sí, así que cualquier flujo del portal que dependiera de acceder a recursos ajenos empezará a fallar con 401. Eso es lo correcto, pero conviene desplegar el front primero si alguna vista lo hace.

Dos condiciones de los datos que conviene medir en producción **antes** de desplegar, porque determinan si algún usuario real empieza a ver 401:

```sql
SELECT count(*) FROM clients WHERE "companyId" IS NULL;
SELECT count(*) FROM companies WHERE "distributorId" IS NULL;
```

Una empresa pierde acceso a los clientes que no tengan `companyId` asignado, y una distribuidora a las empresas sin `distributorId`. Si esos conteos no son cero, hay que asignar los vínculos antes o aceptar el 401. En la base local ambos son distintos de cero, así que el riesgo es concreto, no teórico.


## Cambios tras la revisión

Una revisión independiente confirmó que los 13 sitios bloquean como corresponde y que ningún rol legítimo pierde acceso, pero encontró tres cosas que se corrigieron acá.

**Un 500 que este PR activaba.** `company.controller.js` y `distributor.controller.js` lanzaban `ErrorHandler(unauthorized)` sin tener `unauthorized` importado. La rama era inalcanzable mientras la llamada iba sin `await`; al activarla, `PUT /companies/:id/edit` respondía `500 {"error":"unauthorized is not defined"}` en vez de 401. Falla cerrado, así que no era un agujero, pero es exactamente la confusión que este PR dice arreglar en `well.controller`.

**Un N+1 en el lote.** `assertOwnsReports` llamaba a `checkPermissions` una vez por reporte, y para un solicitante `company` eso es una query por reporte: 180 reportes medidos en 180 queries secuenciales. El botón de "seleccionar todo" del portal puede mandar miles. Ahora se agrupa por cliente distinto, que en la práctica es uno o dos por lote.

**Un fail-open sobre datos huérfanos.** Un reporte cuyo `well.client` no se pudiera resolver caía en `checkPermissions(admin, undefined)`, que devuelve `true` por la rama de admin. Hoy imposible por las FK, pero ahora se niega explícitamente.

El test pasa de 16 a 21 casos, e incorpora un guardián que recorre `src/` y falla nombrando archivo y línea si alguna invocación pierde el `await`. Verificado en negativo: quitando un `await` a propósito, el test falla e indica `controllers/client.controller.js:70`.

## Hallazgos graves que este PR NO resuelve

La revisión encontró tres agujeros preexistentes, fuera del alcance de estos dos issues. Se abren por separado, pero conviene saberlos al leer este PR, porque **dos de ellos permiten sortear la autorización que este PR construye**:

- `POST /companies/:id/clients/:clientId` no valida nada: una empresa se asigna a sí misma cualquier cliente ajeno y a partir de ahí todos los chequeos de este PR le dan acceso legítimo. Su reverso, `removeClientFromCompany`, desengancha clientes ajenos.
- `POST /distributors/:id/companies/:companyId`, lo mismo un nivel arriba. Y el descenso distribuidora → cliente que agrega este PR es lo que lo convierte en acceso a datos de clientes.
- `PUT /clients/:id/edit` acepta `roleId` en el body y lo persiste: **un cliente `normal` se convierte en admin editándose a sí mismo**. Verificado. Es el más grave de los tres y no depende de este PR.

## Guardrail agregado: el test destructivo ya no puede borrar la base equivocada

`tests/models/user.test.js` hace `sequelize.sync({ force: true })`, que elimina y recrea todas las tablas de la base a la que apunte la conexión. Qué base es eso lo decide `NODE_ENV`.

**Hoy no ocurre un desastre, pero por casualidad y no por diseño.** Jest fija `NODE_ENV=test` cuando la variable no viene definida, y dotenv no sobreescribe variables ya presentes, así que el `NODE_ENV=development` del `.env` se ignora y la conexión termina apuntando a `<DB_NAME>_test`, que no existe. Falla al conectar en vez de borrar. Verificado ejecutando:

```
$ npx jest tests/models/user.test.js
SequelizeConnectionError: database "wellproject_dev_test" does not exist
```

Basta con que `NODE_ENV` venga exportado en el entorno para que esa protección desaparezca en silencio, y ahí sí apunta a la base real:

```
$ NODE_ENV=development npx jest tests/models/user.test.js
⛔ Test destructivo detenido: iba a borrar todas las tablas de una base que no es de pruebas.
   destino:  wellproject_dev@localhost
   problema: NODE_ENV es "development" y tiene que ser "test"
   problema: la base es "wellproject_dev" y su nombre tiene que terminar en "_test"
```

Ese mensaje es el guard nuevo (`tests/helpers/safe-database.js`), que exige las dos condiciones —entorno `test` y nombre de base terminado en `_test`— antes de permitir el borrado. Se piden las dos a propósito: la primera se sobreescribe fácil desde el shell, y la segunda es la que de verdad protege la base equivocada.

Además el script pasa a ser `"test": "NODE_ENV=test jest"`, para que la protección no dependa de un default de jest que puede cambiar entre versiones.

Los conteos de la base local antes y después de ambos intentos: 8 usuarios, 4 clientes, 5 pozos, 188 reportes. Sin cambios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
