### PR TITLE
fix: impide que un usuario se ascienda a admin editando su propio perfil

### DIFF
--- a/API/models/client.js
+++ b/API/models/client.js
@@ -32,6 +32,22 @@ module.exports = (sequelize, DataTypes) => {
     modelName: 'client',
   });
 
+  // Sólo estos campos se pueden tocar desde el formulario de edición.
+  // `validate-params` no sirve de filtro: comprueba los campos que declara,
+  // pero deja pasar intactos los que no, así que sin esta lista el body llega
+  // entero a `update()` y se puede escribir cualquier columna, incluidas `id`,
+  // `userId` y `createdBy`.
+  // `encrypted_password` queda fuera a propósito: lo maneja
+  // `handlePasswordChange`, que la hashea. Escribirla por acá la guardaría en
+  // texto plano y dejaría la cuenta sin poder iniciar sesión.
+  const CAMPOS_EDITABLES_USER = ['name', 'email', 'roleId', 'isActived'];
+  const CAMPOS_EDITABLES_PERSON = ['fullName', 'personalEmail', 'phoneNumber', 'location'];
+
+  const soloCampos = (data, permitidos) =>
+    Object.fromEntries(
+      Object.entries(data).filter(([campo]) => permitidos.includes(campo))
+    );
+
   client.prototype.updateDetails = async function (user, person, data) {
     if (data.encrypted_password) {
       const isPasswordValid = await user.checkPasswordValidation(data.encrypted_password);
@@ -39,8 +55,8 @@ module.exports = (sequelize, DataTypes) => {
         throw new ErrorHandler(badPasswordValidation);
       }
     }
-    await user.update(data);
-    await person.update(data);
+    await user.update(soloCampos(data, CAMPOS_EDITABLES_USER));
+    await person.update(soloCampos(data, CAMPOS_EDITABLES_PERSON));
   }
 
   client.prototype.checkUserPasswordValidation = async function (password) {

--- a/API/models/company.js
+++ b/API/models/company.js
@@ -67,6 +67,18 @@ module.exports = (sequelize, DataTypes) => {
     modelName: 'company',
   });
 
+  // Ver el comentario equivalente en `models/client.js`: el body llega crudo
+  // desde el controlador y sin esta lista se puede escribir cualquier columna.
+  const CAMPOS_EDITABLES_USER = ['name', 'email', 'roleId', 'isActived'];
+  const CAMPOS_EDITABLES_COMPANY = [
+    'companyLogo', 'companyRut', 'phoneNumber', 'recoveryEmail', 'location', 'distributorId',
+  ];
+
+  const soloCampos = (data, permitidos) =>
+    Object.fromEntries(
+      Object.entries(data).filter(([campo]) => permitidos.includes(campo))
+    );
+
   company.prototype.updateDetails = async function (user, data) {
     if (data.encrypted_password) {
       const isPasswordValid = await user.checkPasswordValidation(data.encrypted_password);
@@ -74,8 +86,8 @@ module.exports = (sequelize, DataTypes) => {
         throw new ErrorHandler(badPasswordValidation);
       }
     }
-    await user.update(data);
-    await this.update(data);
+    await user.update(soloCampos(data, CAMPOS_EDITABLES_USER));
+    await this.update(soloCampos(data, CAMPOS_EDITABLES_COMPANY));
   }
 
   return company;

--- a/API/models/distributor.js
+++ b/API/models/distributor.js
@@ -73,6 +73,18 @@ module.exports = (sequelize, DataTypes) => {
     }
   );
 
+  // Ver el comentario equivalente en `models/client.js`: el body llega crudo
+  // desde el controlador y sin esta lista se puede escribir cualquier columna.
+  const CAMPOS_EDITABLES_USER = ["name", "email", "roleId", "isActived"];
+  const CAMPOS_EDITABLES_DISTRIBUTOR = [
+    "distributorLogo", "distributorRut", "phoneNumber", "recoveryEmail", "location",
+  ];
+
+  const soloCampos = (data, permitidos) =>
+    Object.fromEntries(
+      Object.entries(data).filter(([campo]) => permitidos.includes(campo))
+    );
+
   distributor.prototype.updateDetails = async function (user, data) {
     if (data.encrypted_password) {
       const isPasswordValid = await user.checkPasswordValidation(
@@ -82,8 +94,8 @@ module.exports = (sequelize, DataTypes) => {
         throw new ErrorHandler(badPasswordValidation);
       }
     }
-    await user.update(data);
-    await this.update(data);
+    await user.update(soloCampos(data, CAMPOS_EDITABLES_USER));
+    await this.update(soloCampos(data, CAMPOS_EDITABLES_DISTRIBUTOR));
   };
 
   return distributor;

--- a/API/src/controllers/client.controller.js
+++ b/API/src/controllers/client.controller.js
@@ -1,6 +1,7 @@
 const db = require('../../models');
 const ErrorHandler = require('../utils/error.util');
 const checkPermissionsForClientResources = require('../utils/check-permissions');
+const assertCanChangeRole = require('../utils/assert-role-change');
 const {
   unauthorized,
   userHasNoClientAssociated,
@@ -70,6 +71,8 @@ const editClient = async (req, res, next) => {
     if (!await checkPermissionsForClientResources(req.user, client)) {
       throw new ErrorHandler(unauthorized);
     }
+
+    assertCanChangeRole(req.user, user, req.body);
 
     const password = req.body.encrypted_password;
 

--- a/API/src/controllers/company.controller.js
+++ b/API/src/controllers/company.controller.js
@@ -1,6 +1,7 @@
 const db = require('../../models');
 const ErrorHandler = require('../utils/error.util');
 const checkPermissionsForClientResources = require('../utils/check-permissions');
+const assertCanChangeRole = require('../utils/assert-role-change');
 const { companyNotFound, clientNotFound, clientDoesntBelongToCompany, clientHasNoUserOrPersonAssociated, unauthorized } = require('../utils/errorcodes.util');
 
 const Company = db.company;
@@ -199,6 +200,8 @@ const editCompany = async (req, res, next) => {
     if (!await checkPermissionsForClientResources(req.user, company)) {
       throw new ErrorHandler(unauthorized);
     }
+
+    assertCanChangeRole(req.user, user, req.body);
 
     const password = req.body.encrypted_password;
 

--- a/API/src/controllers/distributor.controller.js
+++ b/API/src/controllers/distributor.controller.js
@@ -1,6 +1,7 @@
 const db = require("../../models");
 const ErrorHandler = require("../utils/error.util");
 const checkPermissionsForClientResources = require("../utils/check-permissions");
+const assertCanChangeRole = require("../utils/assert-role-change");
 const {
   companyNotFound,
   distributorNotFound,
@@ -191,6 +192,10 @@ const editDistributor = async (req, res, next) => {
     if (!await checkPermissionsForClientResources(req.user, distributor)) {
       throw new ErrorHandler(unauthorized);
     }
+
+    // Hoy la ruta es admin-only, así que es un no-op. Va igual para que
+    // ampliar los roles de la ruta no reabra el escalamiento en silencio.
+    assertCanChangeRole(req.user, user, req.body);
 
     const password = req.body.encrypted_password;
 

--- a/API/src/utils/assert-role-change.js
+++ b/API/src/utils/assert-role-change.js
@@ -1,0 +1,36 @@
+const ErrorHandler = require('./error.util');
+const { unauthorized } = require('./errorcodes.util');
+
+// Sólo un admin puede cambiar el rol de una cuenta.
+//
+// Los formularios de edición del portal mandan `roleId` siempre, con el valor
+// actual precargado en el selector. Por eso no se puede prohibir el campo a
+// secas: hay que dejar pasar el que no cambia nada y rechazar sólo el cambio
+// real. Si no, se rompe que una empresa edite a sus clientes.
+//
+// Sin esta comprobación, cualquier usuario que pueda editar una cuenta puede
+// convertirla en admin, empezando por la suya: `updateDetails` aplica el body
+// tal cual sobre el modelo `user`, y `validate-params` declara `roleId` como
+// opcional en vez de prohibido.
+const assertCanChangeRole = (requester, targetUser, body) => {
+  if (body.roleId === undefined || body.roleId === null || body.roleId === '') {
+    return;
+  }
+
+  // El body llega como JSON y el selector del portal manda strings.
+  const solicitado = parseInt(body.roleId, 10);
+
+  if (Number.isNaN(solicitado)) {
+    throw new ErrorHandler(unauthorized);
+  }
+
+  if (solicitado === targetUser.roleId) {
+    return;
+  }
+
+  if (requester.type !== 'admin') {
+    throw new ErrorHandler(unauthorized);
+  }
+};
+
+module.exports = assertCanChangeRole;

--- a/API/src/utils/assert-role-change.js
+++ b/API/src/utils/assert-role-change.js
@@ -18,11 +18,27 @@ const assertCanChangeRole = (requester, targetUser, body) => {
   }
 
   // El body llega como JSON y el selector del portal manda strings.
-  const solicitado = parseInt(body.roleId, 10);
+  //
+  // Se usa Number y no parseInt: parseInt lee un prefijo y descarta el resto,
+  // así que `parseInt('2_0')` da 2 y la comprobación creería que el rol no
+  // cambia. Postgres, en cambio, castea `'2_0'::integer` a 20 —admite el guion
+  // bajo como separador de dígitos desde la versión 16—, así que se escribiría
+  // un rol distinto del que se validó. Number rechaza esas cadenas enteras.
+  const solicitado = Number(body.roleId);
 
-  if (Number.isNaN(solicitado)) {
+  // Number('') es 0 y Number([1]) es 1, así que no basta con Number.isInteger:
+  // se exige que el valor original sea un número o una cadena numérica.
+  const esEntero =
+    Number.isInteger(solicitado) &&
+    (typeof body.roleId === 'number' || typeof body.roleId === 'string');
+
+  if (!esEntero) {
     throw new ErrorHandler(unauthorized);
   }
+
+  // Se normaliza el body para que lo que se persista sea exactamente el valor
+  // que se acaba de validar, y no la cadena cruda que Postgres reinterpretaría.
+  body.roleId = solicitado;
 
   if (solicitado === targetUser.roleId) {
     return;

--- a/API/tests/utils/assert-role-change.test.js
+++ b/API/tests/utils/assert-role-change.test.js
@@ -12,7 +12,18 @@ const CLIENTE = { id: 5, type: 'normal' };
 // Sólo se mira `roleId`; es el usuario dueño de la cuenta que se edita.
 const cuentaNormal = { id: 5, roleId: 2 };
 
-const lanza = (fn) => expect(fn).toThrow();
+const ErrorHandler = require('../../src/utils/error.util');
+
+// Se comprueba el tipo y el status, no sólo que lance: un TypeError accidental
+// también satisfaría un `toThrow()` a secas, y eso sería un 500, no un 401.
+const lanza = (fn) => {
+  expect(fn).toThrow(ErrorHandler);
+  try {
+    fn();
+  } catch (e) {
+    expect(e.statusCode).toBe(401);
+  }
+};
 const noLanza = (fn) => expect(fn).not.toThrow();
 
 describe('assertCanChangeRole', () => {
@@ -36,6 +47,39 @@ describe('assertCanChangeRole', () => {
     it('rechaza un roleId que no es un número', () => {
       lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: 'admin' }));
     });
+
+    it('rechaza cadenas que parseInt truncaría y Postgres leería distinto', () => {
+      // `parseInt('2_0')` da 2, así que una comprobación con parseInt creería
+      // que el rol no cambia. Postgres castea `'2_0'::integer` a 20 desde la
+      // versión 16, y `users.roleId` no tiene FK, así que el valor entra.
+      // No escala a admin, pero deja la cuenta con un rol inexistente y
+      // `generateToken` revienta al buscarlo: el login queda en 500 para
+      // siempre. Una empresa podría dejar así a cualquiera de sus clientes.
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: '2_0' }));
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: '2_00' }));
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: '20_1' }));
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: '2abc' }));
+    });
+
+    it('rechaza decimales, que además filtraban el mensaje de error de Postgres', () => {
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: 2.9 }));
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: '2.9' }));
+    });
+
+    it('rechaza tipos que Number coacciona a un entero', () => {
+      // Number([1]) es 1 y Number(true) es 1: sin comprobar el tipo original,
+      // ambos pasarían por un roleId válido.
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: [1] }));
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: true }));
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: {} }));
+    });
+
+    it('normaliza el body para que se persista el valor validado', () => {
+      // Si se dejara la cadena cruda, Postgres la reinterpretaría al escribir.
+      const body = { roleId: '3' };
+      assertCanChangeRole(ADMIN, cuentaNormal, body);
+      expect(body.roleId).toBe(3);
+    });
   });
 
   describe('no estorba a los flujos legítimos', () => {
@@ -49,6 +93,11 @@ describe('assertCanChangeRole', () => {
     it('deja pasar cuando el body no trae roleId', () => {
       noLanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { name: 'Nuevo' }));
       noLanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: null }));
+      // Ojo: este guard ignora `roleId: ''` porque equivale a no mandarlo, pero
+      // esa petición hoy tumba el proceso antes de llegar acá. `validate-params`
+      // hace `Role.findByPk('')` y el rechazo de Postgres queda sin capturar.
+      // No es asunto de esta función, pero no hay que leer este caso como que
+      // el endpoint lo tolera: no lo tolera. Está en el issue #80.
       noLanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: '' }));
     });
 

--- a/API/tests/utils/assert-role-change.test.js
+++ b/API/tests/utils/assert-role-change.test.js
@@ -1,0 +1,60 @@
+// assert-role-change.test.js
+//
+// Sin base de datos: la función es pura. Ver la nota en
+// `tests/utils/check-permissions.test.js` sobre por qué se evita la base.
+
+const assertCanChangeRole = require('../../src/utils/assert-role-change');
+
+const ADMIN = { id: 1, type: 'admin' };
+const EMPRESA = { id: 4, type: 'company' };
+const CLIENTE = { id: 5, type: 'normal' };
+
+// Sólo se mira `roleId`; es el usuario dueño de la cuenta que se edita.
+const cuentaNormal = { id: 5, roleId: 2 };
+
+const lanza = (fn) => expect(fn).toThrow();
+const noLanza = (fn) => expect(fn).not.toThrow();
+
+describe('assertCanChangeRole', () => {
+  describe('bloquea el escalamiento', () => {
+    it('un cliente no puede convertirse en admin', () => {
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: 1 }));
+    });
+
+    it('tampoco mandando el rol como string, que es lo que envía el selector', () => {
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: '1' }));
+    });
+
+    it('una empresa no puede ascender a su cliente', () => {
+      lanza(() => assertCanChangeRole(EMPRESA, cuentaNormal, { roleId: 1 }));
+    });
+
+    it('una empresa no puede ascenderse a sí misma', () => {
+      lanza(() => assertCanChangeRole(EMPRESA, { id: 4, roleId: 3 }, { roleId: 1 }));
+    });
+
+    it('rechaza un roleId que no es un número', () => {
+      lanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: 'admin' }));
+    });
+  });
+
+  describe('no estorba a los flujos legítimos', () => {
+    it('deja pasar el roleId sin cambios que manda el formulario del portal', () => {
+      // El selector viene precargado con el rol actual, así que el campo viaja
+      // siempre. Prohibirlo a secas rompería la edición de clientes.
+      noLanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: 2 }));
+      noLanza(() => assertCanChangeRole(EMPRESA, cuentaNormal, { roleId: '2' }));
+    });
+
+    it('deja pasar cuando el body no trae roleId', () => {
+      noLanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { name: 'Nuevo' }));
+      noLanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: null }));
+      noLanza(() => assertCanChangeRole(CLIENTE, cuentaNormal, { roleId: '' }));
+    });
+
+    it('un admin sí puede cambiar el rol', () => {
+      noLanza(() => assertCanChangeRole(ADMIN, cuentaNormal, { roleId: 3 }));
+      noLanza(() => assertCanChangeRole(ADMIN, cuentaNormal, { roleId: 1 }));
+    });
+  });
+});


### PR DESCRIPTION
## Issues relacionados

Cierra **#78**. Sin ticket de Jira asociado.

Sólo backend, y no cambia ningún contrato que el portal consuma. No aplica la regla de front-primero.

## Descripción del problema: cualquier usuario se hace admin editando su propio perfil

`PUT /clients/:id/edit` acepta `roleId` en el body y lo escribe tal cual sobre el modelo `user`. Un cliente `normal` se asciende a admin editando su propio perfil, que es un recurso al que accede legítimamente: no necesita tocar nada ajeno ni sortear ninguna validación de pertenencia.

Verificado contra la base local antes de tocar el código:

```
estado inicial: user 5 (emifpg@gmail.com) roleId=2   ← 2 = normal

PUT /clients/3/edit  {roleId: 1}  →  200 {"message":"Cliente 3 editado exitosamente."}

roleId después: 1
🔴 ESCALAMIENTO CONFIRMADO
   con sesión nueva, GET /clients/6/wells (cliente ajeno) → 200
   GET /users → 200 (8 usuarios)
```

El token que el usuario ya tiene sigue diciendo `type: normal` hasta que expire, pero basta volver a iniciar sesión para recibir uno de admin. Lo mismo ocurre en `PUT /companies/:id/edit`, donde una empresa se asciende a sí misma.

Esto es más grave que los IDOR del PR #77: aquellos requerían apuntar a un recurso ajeno, éste funciona sobre el propio.

### Son dos defectos encadenados, y hay que cerrar los dos

**`roleId` está declarado opcional en vez de prohibido** (`client.params.js:48`), al contrario que `id`, `userId`, `createdAt` y `updatedAt`, que sí son `forbidden`.

Pero **no se puede prohibir a secas**. El selector de rol del portal (`userForm.js:420`) manda el campo siempre, precargado con el valor actual. Rechazar cualquier `roleId` rompería la edición de clientes para todos, empezando por el admin, que es quien legítimamente cambia roles.

**`updateDetails` aplica el body crudo** (`models/client.js:35`, y lo mismo en `company.js:70` y `distributor.js:76`):

```js
await user.update(data);
await person.update(data);
```

Y `validate-params` no es un filtro: su bucle recorre `Object.entries(paramsSpec)`, así que comprueba los campos que declara y **deja pasar intactos los que no**. Cualquier columna del modelo es escribible mandándola en el body, esté declarada o no. Ese es el defecto de fondo: aunque se arreglara `roleId`, el siguiente campo sensible seguiría expuesto.

## Solución propuesta: restringir el cambio, no el campo

**`assertCanChangeRole`** deja pasar el `roleId` que no cambia nada —el que manda el formulario— y exige rol admin para el cambio real. El portal sigue funcionando y el escalamiento se cierra. Acepta strings porque el selector los envía así, pero los convierte con `Number` y no con `parseInt` (ver "Cambios tras la revisión").

**Allowlist en los tres `updateDetails`.** Sólo se aplican los campos editables conocidos, así que `createdBy`, `id` o `userId` no se pueden inyectar aunque no estén declarados en el spec.

`encrypted_password` queda **deliberadamente fuera** del allowlist. La maneja `handlePasswordChange`, que la hashea; escribirla por esta vía la guardaría en texto plano y dejaría la cuenta sin poder iniciar sesión.

En `distributor.controller.js` el guard es hoy un no-op, porque la ruta es admin-only. Va igual para que ampliar los roles de esa ruta más adelante no reabra el agujero en silencio.

## Screenshots

No aplica: no hay cambios visuales.

## Cómo probar

**Tests incorporados**

12 casos en `tests/utils/assert-role-change.test.js`, sin base de datos. Con los del PR anterior:

```
npx jest tests/utils/
Test Suites: 2 passed  ·  Tests: 33 passed, 33 total
```

**Verificación end-to-end contra la base local**

```
EL ESCALAMIENTO
  ✓ cliente se pone roleId 1 (admin) → 401        ✓ y su rol NO cambió → 2
  ✓ cliente lo intenta como string "1" → 401      ✓ sigue sin cambiar → 2
  ✓ empresa asciende a su cliente a admin → 401   ✓ sigue sin cambiar → 2
  ✓ empresa se asciende a sí misma → 401          ✓ la empresa sigue con rol 3

LO QUE DEBE SEGUIR FUNCIONANDO
  ✓ cliente edita su nombre → 200
  ✓ cliente manda su roleId actual sin cambiarlo (lo que hace el portal) → 200
  ✓ empresa edita a su cliente mandando roleId igual → 200
  ✓ ADMIN sí puede cambiar el rol → 200, y el rol cambia

INYECCIÓN DE COLUMNAS (el allowlist)
  ✓ el nombre sí se actualizó          ✓ createdBy NO se pudo inyectar
```

El e2e del PR #77 se volvió a correr entero y sigue en verde, así que la autorización por pertenencia no se tocó. La base local quedó restaurada y verificada: 8 usuarios, 5 pozos, 188 reportes, y los roles y correos en sus valores originales.

**En el portal, a mano**

- Que un admin cambie el rol de un usuario desde el formulario: debe seguir funcionando.
- Que una empresa edite a uno de sus clientes: debe seguir funcionando.
- Que un cliente edite su propio nombre y teléfono: debe seguir funcionando.

## Cambios tras la revisión

Una revisión independiente confirmó que **no hay regresión**: contrastó los campos que envían los tres formularios del portal contra los allowlists, y están los 27 cubiertos (8 del formulario de cliente, 10 del de empresa, 9 del de distribuidora). También verificó que el cambio de contraseña sigue funcionando por `handlePasswordChange` y que la columna queda hasheada.

Pero encontró **un bypass en el guard que había escrito**, y se corrige en este PR.

`parseInt` lee un prefijo y descarta el resto; Postgres castea la cadena completa. Con `roleId: "2_0"`, `parseInt` da 2 y el guard creía que el rol no cambiaba, pero Postgres escribe **20** — desde la versión 16 admite el guion bajo como separador de dígitos, y `users.roleId` no tiene FK.

No escala a admin: el valor que persiste conserva el prefijo que `parseInt` consumió, así que desde 2 sólo se alcanzan 20–29, 200–299, nunca 1. El daño es dejar la cuenta con un rol inexistente, y ahí `generateToken` hace `getRole()` sobre `null`: **el login queda en 500 de forma permanente**. Una empresa podía dejar así a cualquiera de sus clientes con una sola petición.

Se pasa a `Number`, que rechaza esas cadenas enteras, comprobando además el tipo original porque `Number([1])` es 1 y `Number(true)` es 1. Y se normaliza `body.roleId` al entero validado, para que lo que se escriba sea exactamente lo que se comprobó.

Verificado end-to-end contra Postgres 16.14: las ocho variantes (`"2_0"`, `"2_00"`, `"20_1"`, `"2abc"`, `2.9`, `"2.9"`, `[1]`, `true`) responden 401 dejando el rol intacto, y un admin cambiando el rol con string persiste el entero exacto.

En los tests, `lanza()` pasa a exigir `ErrorHandler` con status 401: un `TypeError` accidental también satisfacía un `toThrow()` a secas, y eso sería un 500. Los casos suben de 8 a 12, y el total de `tests/utils/` de 29 a 33.

## Hallazgos graves que este PR no resuelve

La revisión destapó dos defectos preexistentes, ya con issue propio:

- **#80 — una petición anónima al login mata el proceso del API.** `validate-params` hace `Role.findByPk(req.body.roleId)` sin validar, y cualquier valor no entero deja una rejection sin capturar que tumba Node. Como producción corre nodemon, el proceso no se reinicia. Lo reproduje en vivo: es el mismo modo de falla del incidente del 4 de agosto, pero **sin autenticación y repetible a voluntad**. Es lo más urgente que hay abierto.
- **#81 — `PUT` de un pozo permite sobrescribir sus credenciales DGA y moverlo a otra cuenta.** Es el cuarto caso de la misma asignación masiva que este PR cierra en los otros tres modelos, y justo el que toca la tabla con las credenciales irrotables.

Sobre el segundo, vale ser explícito: **este PR cierra tres de los cuatro `update(req.body)` del código.** El defecto de fondo es que `validate-params` no es un whitelist —comprueba lo que declara y deja pasar el resto—, así que cada `update(req.body)` restante es una asignación masiva esperando.

## Lo que este PR no resuelve

El mismo endpoint permite cambiar el `email` de la cuenta. Para el dueño de la cuenta es razonable; para una empresa sobre su cliente es discutible y merece decisión de producto, así que no se toca acá.

Tampoco cierra los otros dos hallazgos de la revisión del #77, que van en issues aparte: `POST /companies/:id/clients/:clientId` y `POST /distributors/:id/companies/:companyId` no validan pertenencia y permiten sortear la autorización que aquel PR construyó.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
