### PR TITLE
fix: evita que una petición anónima al login mate el proceso del API

### DIFF
--- a/API/src/controllers/user.controller.js
+++ b/API/src/controllers/user.controller.js
@@ -198,9 +198,14 @@ const getUserInfoById = async (req, res, next) => {
 //                USER AUTH
 
 const registerUser = async (req, res, next) => {
-  const transaction = await sequelize.transaction();
+  // Se declara fuera y se abre dentro del try: si `transaction()` falla —por
+  // ejemplo con el pool agotado—, era el único `await` de un handler que
+  // quedaba fuera de un try en todo el repo, así que su rechazo no lo recogía
+  // nadie y mataba el proceso.
+  let transaction;
 
   try {
+    transaction = await sequelize.transaction();
     const { id: requesterId, type: requesterRole } = req.user;
     if (!await checkPermissionsForClientResources(req.user, undefined, true)) {
       throw new ErrorHandler(unauthorized);
@@ -410,7 +415,20 @@ const registerUser = async (req, res, next) => {
     const token = await user.generateToken();
     res.json({ user, token });
   } catch (error) {
-    await transaction.rollback();
+    // Sólo se revierte si la transacción sigue abierta. Buena parte de este
+    // handler corre DESPUÉS del commit (los registros de actividad y
+    // `generateToken`), y si algo falla ahí, el rollback sobre una transacción
+    // ya cerrada lanza «Transaction cannot be rolled back because it has been
+    // finished with state: commit». Ese throw ocurre dentro del catch, así que
+    // nadie lo recoge: `next(error)` no llega a correr, el cliente se queda sin
+    // respuesta y el proceso muere por rejection no capturada.
+    if (transaction && !transaction.finished) {
+      try {
+        await transaction.rollback();
+      } catch (rollbackError) {
+        console.error(`[users] falló el rollback del registro: ${rollbackError.message}`);
+      }
+    }
     next(error);
   }
 };

--- a/API/src/middlewares/validate-params.middleware.js
+++ b/API/src/middlewares/validate-params.middleware.js
@@ -35,6 +35,10 @@ const resolverTipoDeRol = async (body) => {
     throw new ErrorHandler({ message: 'El parámetro roleId no es válido', code: 400 });
   }
 
+  // Se normaliza en el body para que el controlador reciba el entero validado
+  // y no la cadena cruda, igual que hace `assert-role-change.js`.
+  body.roleId = id;
+
   const role = await Role.findByPk(id);
   return role?.type;
 };

--- a/API/src/middlewares/validate-params.middleware.js
+++ b/API/src/middlewares/validate-params.middleware.js
@@ -5,61 +5,99 @@ const {
 const db = require("../../models");
 const Role = db.role;
 
+// Resuelve el tipo de rol a partir del body, sin dejar que un valor mal formado
+// tumbe el proceso.
+//
+// `Role.findByPk(req.body.roleId)` con un valor no entero hace que Postgres
+// rechace la consulta, y el error quedaba como rejection sin capturar dentro de
+// un middleware async: Node mataba el proceso. Como este bloque corre en todas
+// las rutas que usan el middleware —incluida `POST /users/login`, que es
+// pública—, bastaba una petición anónima para dejar la API caída.
+//
+// Se usa `Number` y no `parseInt` porque `parseInt('2_0')` da 2 mientras
+// Postgres castea `'2_0'::integer` a 20. Mismo criterio que en
+// `assert-role-change.js`.
+const resolverTipoDeRol = async (body) => {
+  if (body.roleType) {
+    return body.roleType;
+  }
+
+  const { roleId } = body;
+  if (roleId === undefined || roleId === null || roleId === '') {
+    return undefined;
+  }
+
+  const id = Number(roleId);
+  const esEntero =
+    Number.isInteger(id) && (typeof roleId === 'number' || typeof roleId === 'string');
+
+  if (!esEntero) {
+    throw new ErrorHandler({ message: 'El parámetro roleId no es válido', code: 400 });
+  }
+
+  const role = await Role.findByPk(id);
+  return role?.type;
+};
+
 function validateParams(paramsSpec, registerUser = false) {
   return async function (req, res, next) {
-    const errors = [];
-    const forbidden = [];
-    const params = []
-
-    // Si la validación proviene del registro de usuarios, es necesario
-    // hacer una excepción, puesto que si el usuario es normal o admin, se
-    // necesitan parámetros de Person, pero si es empresa, se necesitan parámetros
-    // de Company
-    // No loguear `req.body`: este middleware corre en /users/login y
-    // /users/register (contraseña del usuario en texto plano) y en la
-    // creación y edición de pozos (credenciales DGA).
-
-    let type = req.body.roleType;
-
-    if (!type) {
-      const role = await Role.findByPk(req.body.roleId)
-      type = role?.type
-    }
-
-    if (registerUser) {
-      if (type == 'admin' || type == 'normal') {
-        // excluir campos específicos de Company
-        delete paramsSpec.companyLogo;
-        delete paramsSpec.companyRut;
-        delete paramsSpec.recoveryEmail;
-      } else if (type === 'company') {
-        // excluir campos específicos de Person
-        delete paramsSpec.fullName;
-        delete paramsSpec.location;
-        delete paramsSpec.phoneNumber;
-        delete paramsSpec.personalEmail;
-      } else if (type === 'distributor') {
-        // excluir campos específicos de Person
-        delete paramsSpec.fullName;
-        delete paramsSpec.location;
-        delete paramsSpec.phoneNumber;
-        delete paramsSpec.personalEmail;
-      }
-    }
-
-    for (const [key, value] of Object.entries(paramsSpec)) {
-      const paramValue = req.body[key];
-      if (value.required && (paramValue == undefined || paramValue == null || paramValue == '')) {
-        errors.push(`${key}`);
-      }
-      if (value.forbidden && (paramValue != undefined && paramValue != null && paramValue != '')) {
-        forbidden.push(`${key}`);
-      }
-      if (paramValue != undefined && paramValue != null && paramValue != '') {
-        params.push({ key, value: paramValue });
-      }
-    }
     try {
+      const errors = [];
+      const forbidden = [];
+      const params = []
+
+      // No loguear `req.body`: este middleware corre en /users/login y
+      // /users/register (contraseña del usuario en texto plano) y en la
+      // creación y edición de pozos (credenciales DGA).
+
+      const type = await resolverTipoDeRol(req.body);
+
+      // Se trabaja sobre una copia. `paramsSpec` es un objeto de módulo que se
+      // pasa una sola vez al definir la ruta, así que los `delete` de abajo lo
+      // mutaban de forma permanente: tras la primera alta de una empresa, el
+      // spec perdía `fullName`, `location`, `phoneNumber` y `personalEmail`, y
+      // a partir de ahí registrar un cliente ya no los exigía. La validación se
+      // debilitaba sola y dependía del orden de las peticiones.
+      const spec = { ...paramsSpec };
+
+      // Si la validación proviene del registro de usuarios, es necesario
+      // hacer una excepción, puesto que si el usuario es normal o admin, se
+      // necesitan parámetros de Person, pero si es empresa, se necesitan parámetros
+      // de Company
+      if (registerUser) {
+        if (type == 'admin' || type == 'normal') {
+          // excluir campos específicos de Company
+          delete spec.companyLogo;
+          delete spec.companyRut;
+          delete spec.recoveryEmail;
+        } else if (type === 'company') {
+          // excluir campos específicos de Person
+          delete spec.fullName;
+          delete spec.location;
+          delete spec.phoneNumber;
+          delete spec.personalEmail;
+        } else if (type === 'distributor') {
+          // excluir campos específicos de Person
+          delete spec.fullName;
+          delete spec.location;
+          delete spec.phoneNumber;
+          delete spec.personalEmail;
+        }
+      }
+
+      for (const [key, value] of Object.entries(spec)) {
+        const paramValue = req.body[key];
+        if (value.required && (paramValue == undefined || paramValue == null || paramValue == '')) {
+          errors.push(`${key}`);
+        }
+        if (value.forbidden && (paramValue != undefined && paramValue != null && paramValue != '')) {
+          forbidden.push(`${key}`);
+        }
+        if (paramValue != undefined && paramValue != null && paramValue != '') {
+          params.push({ key, value: paramValue });
+        }
+      }
+
       if (errors.length > 0) {
         const missingParametersMessage = `Faltan parámetro(s) requerido(s): ${errors.join(', ')}`;
         throw new ErrorHandler({
@@ -80,13 +118,17 @@ function validateParams(paramsSpec, registerUser = false) {
           code: 400,
         });
       }
+
+      // Un solo `next()`, y sólo si la validación pasó. Antes el `catch`
+      // llamaba a `next(error)` y la ejecución seguía hasta un `next()` final,
+      // así que una petición inválida respondía 400 y ADEMÁS continuaba al
+      // controlador. El controlador intentaba responder sobre una respuesta ya
+      // cerrada, que es el `ERR_HTTP_HEADERS_SENT` que mató el proceso en el
+      // incidente de agosto.
+      next();
     } catch (error) {
-        next(error)
+      next(error);
     }
-    
-
-    next();
-
   };
 }
 

--- a/API/tests/middlewares/validate-params.test.js
+++ b/API/tests/middlewares/validate-params.test.js
@@ -43,8 +43,40 @@ describe('validateParams', () => {
     );
 
     it('acepta un roleId entero y lo consulta normalizado', async () => {
-      await correr(validateParams(spec), { email: 'a@b.cl', roleId: '3' });
+      const body = { email: 'a@b.cl', roleId: '3' };
+      await correr(validateParams(spec), body);
       expect(mockRoleFindByPk).toHaveBeenCalledWith(3);
+      // El controlador debe recibir el entero, no la cadena.
+      expect(body.roleId).toBe(3);
+    });
+
+    it('si la consulta a la base falla, delega el error en vez de reventar', async () => {
+      // Es el escenario de base caída, y es justo la forma del defecto que
+      // este PR cierra: un rechazo sin recoger dentro de un middleware async
+      // mata el proceso.
+      mockRoleFindByPk.mockRejectedValue(new Error('connect ECONNREFUSED'));
+      const llamadas = await correr(validateParams(spec), { email: 'a@b.cl', roleId: 3 });
+      expect(llamadas).toHaveLength(1);
+      expect(llamadas[0]).toBeInstanceOf(Error);
+    });
+
+    it('deja pasar enteros fuera del rango de int4 sin romper', async () => {
+      // Postgres resuelve `int4 = int8` sin error, así que estos llegan a la
+      // consulta y simplemente no encuentran fila. Se fija el comportamiento
+      // para que un cambio futuro no los convierta en un error de casteo.
+      for (const roleId of ['2147483648', '1e30']) {
+        mockRoleFindByPk.mockResolvedValue(null);
+        const llamadas = await correr(validateParams(spec), { email: 'a@b.cl', roleId });
+        expect(llamadas).toEqual([null]);
+      }
+    });
+
+    it('un roleType que no es string no salta la validación', async () => {
+      // `roleType` lo controla quien llama y cortocircuita la consulta a la
+      // base, así que conviene fijar que un objeto no se cuela como tipo.
+      const llamadas = await correr(validateParams(spec), { email: 'a@b.cl', roleType: { a: 1 } });
+      expect(llamadas).toEqual([null]);
+      expect(mockRoleFindByPk).not.toHaveBeenCalled();
     });
 
     it('no consulta la base cuando no viene roleId', async () => {

--- a/API/tests/middlewares/validate-params.test.js
+++ b/API/tests/middlewares/validate-params.test.js
@@ -1,0 +1,134 @@
+// validate-params.test.js
+//
+// Los modelos van mockeados: este archivo no toca la base. Ver la nota en
+// `tests/utils/check-permissions.test.js`.
+
+const mockRoleFindByPk = jest.fn();
+jest.mock('../../models', () => ({
+  role: { findByPk: (...a) => mockRoleFindByPk(...a) },
+}));
+
+const validateParams = require('../../src/middlewares/validate-params.middleware');
+
+// Ejecuta el middleware y devuelve todas las llamadas a `next`, para poder
+// afirmar que se llama exactamente una vez.
+const correr = async (mw, body) => {
+  const llamadas = [];
+  await mw({ body }, {}, (e) => llamadas.push(e || null));
+  return llamadas;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRoleFindByPk.mockResolvedValue({ type: 'normal' });
+});
+
+describe('validateParams', () => {
+  describe('un roleId mal formado no puede tumbar el proceso', () => {
+    // Este bloque corre en POST /users/login, que es público. Antes,
+    // `Role.findByPk('2abc')` dejaba que Postgres rechazara la consulta y la
+    // rejection sin capturar mataba el proceso: una petición anónima bastaba
+    // para dejar la API caída, y con nodemon no se reinicia sola.
+    const spec = { email: { type: 'string', required: true } };
+
+    it.each(['2abc', 'x', '2.9', '2_0', [], {}, true])(
+      'rechaza roleId=%p con 400 en vez de consultar la base',
+      async (roleId) => {
+        const llamadas = await correr(validateParams(spec), { email: 'a@b.cl', roleId });
+        expect(llamadas).toHaveLength(1);
+        expect(llamadas[0]).toBeInstanceOf(Error);
+        expect(llamadas[0].statusCode).toBe(400);
+        expect(mockRoleFindByPk).not.toHaveBeenCalled();
+      }
+    );
+
+    it('acepta un roleId entero y lo consulta normalizado', async () => {
+      await correr(validateParams(spec), { email: 'a@b.cl', roleId: '3' });
+      expect(mockRoleFindByPk).toHaveBeenCalledWith(3);
+    });
+
+    it('no consulta la base cuando no viene roleId', async () => {
+      const llamadas = await correr(validateParams(spec), { email: 'a@b.cl' });
+      expect(llamadas).toEqual([null]);
+      expect(mockRoleFindByPk).not.toHaveBeenCalled();
+    });
+
+    it('trata un roleId vacío como ausente', async () => {
+      const llamadas = await correr(validateParams(spec), { email: 'a@b.cl', roleId: '' });
+      expect(llamadas).toEqual([null]);
+      expect(mockRoleFindByPk).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('next() se llama exactamente una vez', () => {
+    // Antes el catch llamaba a next(error) y la ejecución seguía hasta un
+    // next() final, así que una petición inválida respondía 400 y además
+    // continuaba al controlador, que intentaba responder sobre una respuesta
+    // ya cerrada. Es el ERR_HTTP_HEADERS_SENT del incidente de agosto.
+    const spec = {
+      email: { type: 'string', required: true },
+      id: { type: 'integer', forbidden: true },
+    };
+
+    it('con un parámetro requerido ausente, sólo el error', async () => {
+      const llamadas = await correr(validateParams(spec), { otro: 'x' });
+      expect(llamadas).toHaveLength(1);
+      expect(llamadas[0]).toBeInstanceOf(Error);
+    });
+
+    it('con un parámetro prohibido, sólo el error', async () => {
+      const llamadas = await correr(validateParams(spec), { email: 'a@b.cl', id: 9 });
+      expect(llamadas).toHaveLength(1);
+      expect(llamadas[0].message).toMatch(/prohibido/);
+    });
+
+    it('sin parámetros válidos, sólo el error', async () => {
+      const llamadas = await correr(validateParams(spec), {});
+      expect(llamadas).toHaveLength(1);
+      expect(llamadas[0]).toBeInstanceOf(Error);
+    });
+
+    it('con el body correcto, un solo next() sin error', async () => {
+      const llamadas = await correr(validateParams(spec), { email: 'a@b.cl' });
+      expect(llamadas).toEqual([null]);
+    });
+  });
+
+  describe('el spec no se muta entre peticiones', () => {
+    // `paramsSpec` es un objeto de módulo que se pasa una sola vez al definir
+    // la ruta. Los `delete` del bloque de registro lo mutaban de forma
+    // permanente: tras la primera alta de una empresa, el spec perdía los
+    // campos de Person y registrar un cliente dejaba de exigirlos.
+    const specDeRegistro = () => ({
+      name: { type: 'string', required: true },
+      fullName: { type: 'string', required: true },
+      location: { type: 'string', required: true },
+      phoneNumber: { type: 'string', required: true },
+      personalEmail: { type: 'string', required: false },
+      companyLogo: { type: 'string', required: false },
+      companyRut: { type: 'string', required: false },
+      recoveryEmail: { type: 'string', required: false },
+    });
+
+    it('un alta de empresa no borra los campos de Person del spec', async () => {
+      const spec = specDeRegistro();
+      const original = Object.keys(spec).sort();
+      const mw = validateParams(spec, true);
+
+      await correr(mw, { roleType: 'company', name: 'Empresa', companyRut: '1-9' });
+
+      expect(Object.keys(spec).sort()).toEqual(original);
+    });
+
+    it('tras un alta de empresa, un cliente sin fullName sigue rechazado', async () => {
+      const spec = specDeRegistro();
+      const mw = validateParams(spec, true);
+
+      await correr(mw, { roleType: 'company', name: 'Empresa', companyRut: '1-9' });
+      const llamadas = await correr(mw, { roleType: 'normal', name: 'Cliente' });
+
+      expect(llamadas).toHaveLength(1);
+      expect(llamadas[0].message).toMatch(/fullName/);
+    });
+  });
+});


### PR DESCRIPTION
## Issues relacionados

Cierra **#80** y **#67**. Sin ticket de Jira asociado.

Sólo backend, no cambia contratos. No aplica la regla de front-primero.

**Es el más urgente de los abiertos**: hoy cualquiera puede dejar la API caída con una petición anónima.

## Descripción del problema: una petición anónima al login mata el proceso

`validate-params` resolvía el tipo de rol así:

```js
let type = req.body.roleType;
if (!type) {
  const role = await Role.findByPk(req.body.roleId)
  type = role?.type
}
```

Sin validar `roleId`. Con cualquier valor que no sea un entero, Postgres rechaza la consulta y el `SequelizeDatabaseError` queda como rejection sin capturar dentro de un middleware async: Node mata el proceso.

Ese bloque corre en **todas** las rutas que usan el middleware, incluida `POST /users/login`, que es pública.

Reproducido en vivo, sin ninguna cabecera de autenticación:

```
POST /users/login  {"email":"a@b.cl","password":"x","roleId":"2abc"}

SequelizeDatabaseError: invalid input syntax for type integer: "2abc"
    at validate-params.middleware.js:25:20
[el proceso muere con código 1]
```

Sirve `""`, `"x"`, `"2abc"`, `"2.9"`. Lo descubrí sin querer: un script mío de verificación tumbó el proceso.

### Por qué queda caída y no se levanta sola

Producción arranca con **nodemon** (`CMD ["npm", "run", "dev"]`). Cuando el proceso de Node muere, nodemon no termina: se queda esperando cambios en archivos. Para Docker el PID 1 sigue vivo, así que no aplica ninguna política de reinicio, y `docker ps` muestra el contenedor `Up` mientras Nginx devuelve 502.

Es el modo de falla del incidente del 4 de agosto, con dos diferencias que lo empeoran: **no requiere autenticación** y **es repetible a voluntad**. Mientras está caído se pierde la ingesta de telemetría de los ocho pozos.

El portal además puede dispararlo solo: el selector de rol tiene `<option value="">` y `setValue('roleId', role.id)` sólo corre si el rol actual está en la lista filtrada.

## Solución propuesta

Validar `roleId` antes de consultar y devolver 400. Se usa `Number` y no `parseInt` por el mismo motivo que en `assert-role-change.js`: `parseInt('2_0')` da 2 mientras Postgres castea `'2_0'::integer` a 20.

### Dos defectos más en la misma función

Estaban a pocas líneas y comparten la causa, así que entran acá.

**El doble `next()` (#67).** El `catch` llamaba a `next(error)` y la ejecución seguía hasta un `next()` final:

```js
} catch (error) {
    next(error)
}

next();
```

Una petición inválida respondía 400 **y además** continuaba al controlador, que intentaba responder sobre una respuesta ya cerrada. Ése es el `ERR_HTTP_HEADERS_SENT` que mató el proceso en agosto. Ahora el `try` envuelve la función entera y hay un solo `next()`.

**El spec compartido se mutaba entre peticiones.** Esto no tenía issue y es el hallazgo que más me sorprendió.

`paramsSpec` es un objeto de módulo que se pasa **una sola vez** al definir la ruta, y los `delete` del bloque de registro lo mutaban de forma permanente. Medido:

```
campos del spec al arrancar:        14
después de UNA alta de empresa:     10
se borraron para siempre: fullName, location, phoneNumber, personalEmail
```

O sea que tras la primera alta de una empresa, **registrar un cliente dejaba de exigir sus datos personales** para el resto de la vida del proceso. La validación se debilitaba sola y dependía del orden de las peticiones. Ahora se trabaja sobre una copia.

## Screenshots

No aplica: no hay cambios visuales.

## Cómo probar

**Tests incorporados**

19 casos en `tests/middlewares/validate-params.test.js`, con los modelos mockeados y sin base de datos. Con los anteriores:

```
npx jest tests/middlewares/ tests/utils/
Test Suites: 3 passed  ·  Tests: 52 passed, 52 total
```

El de la mutación del spec se verificó **en negativo**: reintroduciendo el defecto (`const spec = paramsSpec`), los dos tests correspondientes fallan.

**Verificación end-to-end contra la base local**

```
EL DoS ANÓNIMO — POST /users/login, sin token
  ✓ roleId="2abc" → responde y el API sigue viva      ✓ roleId="2.9" → idem
  ✓ roleId=""     → responde y el API sigue viva      ✓ roleId="2_0" → idem
  ✓ roleId="x"    → responde y el API sigue viva

LOGIN NORMAL SIGUE FUNCIONANDO
  ✓ credenciales correctas → 201
  ✓ contraseña incorrecta → 400 "Contraseña incorrecta."
  ✓ sin body → 400

EL DOBLE next() — la petición inválida no llega al controlador
  ✓ registro sin campos requeridos → 400      ✓ y NO se creó ningún usuario

EL SPEC NO SE DEGRADA
  ✓ tras un alta de empresa, un cliente sin fullName sigue rechazado
```

En cada caso del primer bloque se comprobó además que no hubo ninguna rejection sin capturar.

**Después de desplegar**

```bash
curl -i -X POST https://promedicionbackend.com/users/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"a@b.cl","password":"x","roleId":"2abc"}'      # debe dar 400

curl -i https://promedicionbackend.com/well                    # 200: la API sigue viva
```

El segundo es el que importa: confirma que sobrevivió al primero.

## Cambios tras la revisión

Una revisión independiente confirmó que **no hay regresión** en ninguna de las seis rutas que usan el middleware, y verificó que los 16 tests **fallan contra `master`**, así que prueban lo que dicen. También comprobó lo que yo no había medido: 30 disparos seguidos del exploit dan 30 respuestas 400 con el proceso vivo, y valores límite como `2147483648`, `1e30`, `Infinity` o un string de 100k tampoco lo matan.

Un detalle que despeja una duda razonable: el spec ya no se degrada, así que peticiones que **antes pasaban** —por venir después de un alta de empresa, con el spec debilitado— **ahora se rechazan**. La revisión verificó que eso no rompe el portal: `userForm.js` sí manda `fullName`, `location` y `phoneNumber`, y los formularios de empresa y distribuidora mandan `roleType` explícito, que cortocircuita antes de validar.

Pero encontró **dos vías más por las que el proceso podía morir**, con la misma forma que este PR corrige, y se cierran acá.

**`registerUser` hace rollback sobre una transacción ya commiteada** (`user.controller.js:409-415`). Buena parte del handler corre *después* del `commit()`: los registros de actividad y `generateToken`. Si algo falla ahí, el rollback lanza «Transaction cannot be rolled back because it has been finished with state: commit», y ese throw ocurre **dentro del catch**, así que nadie lo recoge: `next(error)` no llega a correr, el cliente se queda sin respuesta y el proceso muere. Verificado ejecutando.

**`sequelize.transaction()` estaba fuera del `try`** (`user.controller.js:201`). Era el único `await` de un handler fuera de un try en todo el repo, así que un fallo al abrir la transacción tampoco lo recogía nadie.

Ahora se revierte sólo si la transacción sigue abierta, y el rollback va envuelto por si falla por otro motivo.

De paso, `resolverTipoDeRol` normaliza `body.roleId` al entero validado, igual que ya hacía `assert-role-change.js`.

Los tests suben de 16 a 19, y el total de `tests/utils/ tests/middlewares/` de 49 a 52. Los tres nuevos cubren lo que la revisión señaló que faltaba: el rechazo de `findByPk` —que es el escenario de base caída y la forma exacta del defecto que este PR cierra—, los enteros fuera del rango de `int4`, y un `roleType` que no es string.

## Lo que este PR no resuelve

Cierra estas tres vías, no la clase de falla. Cualquier otra excepción no capturada produce el mismo escenario mientras sigan abiertos **#64** (sin handlers de `uncaughtException` ni `unhandledRejection`), **#65** (el middleware de errores no comprueba `res.headersSent`) y **#71** (nodemon como runtime, sin healthcheck). Los tres juntos son lo que convierte "la API se muere y queda muerta" en "se reinicia sola y queda registro".

## Hallazgo aparte: faltan foreign keys

Verificando esto encontré que **`companies.userId` y `distributors.userId` no tienen foreign key**, y `users.roleId` tampoco. Borrar un usuario deja la empresa huérfana en vez de cascadear. Ya hay una fila así en la base local (`companies.id = 3` apunta a un `userId` que no existe), anterior a esta sesión. Va en issue aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
