### PR TITLE
fix: agrega la red de seguridad del proceso y deja de filtrar internals en los errores

### DIFF
--- a/API/src/controllers/user.controller.js
+++ b/API/src/controllers/user.controller.js
@@ -5,6 +5,7 @@ const {
   userNotFound,
   passwordsDontMatch,
   unauthorized,
+  clientNotFound,
 } = require("../utils/errorcodes.util");
 const checkPermissionsForClientResources = require("../utils/check-permissions");
 const company = require("../../models/company");
@@ -155,6 +156,9 @@ const getUserInfoById = async (req, res, next) => {
     const { id: clientId } = req.params;
 
     const client = await Client.findByPk(clientId);
+    if (!client) {
+      throw new ErrorHandler(clientNotFound);
+    }
     const userId = client.userId;
 
     if (!await checkPermissionsForClientResources(req.user, client)) {
@@ -179,7 +183,10 @@ const getUserInfoById = async (req, res, next) => {
     const role = await Role.findByPk(user.roleId);
 
     if (!role) {
-      throw new ErrorHandler(roleNotFound);
+      // `roleNotFound` no existe en errorcodes.util, así que esta línea
+      // lanzaba «ReferenceError: roleNotFound is not defined» en vez del 404
+      // que pretendía.
+      throw new ErrorHandler(userNotFound);
     }
 
     const userWithRole = {

--- a/API/src/controllers/well.controller.js
+++ b/API/src/controllers/well.controller.js
@@ -14,7 +14,7 @@ const User = db.user;
 const Person = db.person;
 
 //  TODO: no se esta usando ninguno de estos métodos excepto el activeOrDesactiveWell
-const getAllWells = async (req, res) => {
+const getAllWells = async (req, res, next) => {
   try {
     // Este listado es global y no filtra por cliente, así que no carga las
     // credenciales DGA. Los listados por cliente (/clients/:id/wells) sí las
@@ -24,24 +24,24 @@ const getAllWells = async (req, res) => {
     });
     res.json(wells);
   } catch (error) {
-    res.status(500).send({
-      message: error.message || 'Some error occurred while retrieving Wells'
-    });
+    // Se delega en el middleware de errores. Respondiendo acá con
+    // `error.message` se filtraba el detalle interno —un fallo de conexión
+    // devolvía «connect ECONNREFUSED 127.0.0.1:5432»— y encima por una ruta
+    // que no exige sesión.
+    next(error);
   }
 }
 
-const createWell = async (req, res) => {
+const createWell = async (req, res, next) => {
   try { 
     const well = await Well.create(req.body)
     res.json({created: well})
   } catch (error) {
-    res.status(500).send({
-      message: error.message || 'Some error occurred while creating the Well'
-    });
+    next(error);
   }
 }
 
-const getWellDataByWell = async (req, res) => {
+const getWellDataByWell = async (req, res, next) => {
   try {
     const well = await Well.findOne({ where: { id: req.params.id } });
     if (!well) {
@@ -53,10 +53,7 @@ const getWellDataByWell = async (req, res) => {
     const wellDataInfo = await well.getWellData()
     res.json(wellDataInfo)
   } catch (error) {
-    res.status(500).send({
-      message: error.message || 'Some error occurred while retrieving Well Data'
-    });
-  
+    next(error);
   }
 }
 

--- a/API/src/controllers/wellData.controller.js
+++ b/API/src/controllers/wellData.controller.js
@@ -92,7 +92,7 @@ const normalizeReportNumericFields = (reportData) => {
   };
 };
 
-const createWellData = async (req, res) => {
+const createWellData = async (req, res, next) => {
   try {
     console.log(req.body);
     const well = await Well.findOne({ where: { code: req.body.code } }); // Buscamos el pozo por su código
@@ -123,10 +123,9 @@ const createWellData = async (req, res) => {
     const wellData = await WellData.create(normalizedData);
     res.json(wellData);
   } catch (error) {
-    res.status(500).send({
-      message:
-        error.message || "Some error occurred while creating the WellData",
-    });
+    // Ruta pública de ingesta: respondiendo con `error.message` se filtraba el
+    // detalle interno a cualquiera. Se delega en el middleware de errores.
+    next(error);
   }
 };
 

--- a/API/src/middlewares/error.middleware.js
+++ b/API/src/middlewares/error.middleware.js
@@ -1,7 +1,18 @@
 const { ValidationError, ConnectionError, DatabaseError } = require('sequelize');
 const ErrorHandler = require('../utils/error.util');
 
-const enProduccion = process.env.NODE_ENV === 'production';
+// El stack se registra salvo que se pida lo contrario con LOG_STACK=false.
+//
+// A propósito NO se cuelga de `NODE_ENV === 'production'`: `config/config.js`
+// no tiene bloque `production`, así que con ese valor `models/index.js` resuelve
+// la configuración a `undefined` y la aplicación no arranca. O sea que en este
+// despliegue `NODE_ENV` nunca puede valer `production`, y la condición sería
+// código muerto: creeríamos estar ocultando el stack sin ocultarlo. Peor aún,
+// el día que alguien agregue ese bloque perderíamos el stack en silencio.
+//
+// Hoy conviene registrarlo: no hay Sentry ni agregador de logs, así que
+// `docker logs` es el único diagnóstico disponible.
+const registrarStack = process.env.LOG_STACK !== 'false';
 
 const errorHandler = (err, req, res, next) => {
   // Si la respuesta ya salió, intentar responder de nuevo lanza
@@ -20,7 +31,7 @@ const errorHandler = (err, req, res, next) => {
     name: err.name,
     method: req.method,
     url: req.originalUrl,
-    stack: enProduccion ? undefined : err.stack,
+    stack: registrarStack ? err.stack : undefined,
     at: new Date().toISOString(),
   }));
 

--- a/API/src/middlewares/error.middleware.js
+++ b/API/src/middlewares/error.middleware.js
@@ -1,28 +1,56 @@
 const { ValidationError, ConnectionError, DatabaseError } = require('sequelize');
 const ErrorHandler = require('../utils/error.util');
 
+const enProduccion = process.env.NODE_ENV === 'production';
 
 const errorHandler = (err, req, res, next) => {
-  // Si se necesita mas detalle para el error, se puede console.log(err)
-  console.log(`Error 🚨 | ${err.message} while sending a ${req.method} to ${req.originalUrl}`);
+  // Si la respuesta ya salió, intentar responder de nuevo lanza
+  // ERR_HTTP_HEADERS_SENT, que sin handler de proceso mata la aplicación. Es
+  // el patrón que tumbó producción en agosto de 2026. Se delega en Express
+  // para que cierre el socket sin un segundo envío.
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  // No se loguea `req.body`: este middleware ve /users/login (contraseñas) y la
+  // creación de pozos (credenciales DGA). El stack sólo fuera de producción.
+  console.error(JSON.stringify({
+    level: 'error',
+    msg: err.message,
+    name: err.name,
+    method: req.method,
+    url: req.originalUrl,
+    stack: enProduccion ? undefined : err.stack,
+    at: new Date().toISOString(),
+  }));
+
   if (err instanceof ValidationError) {
     const messages = err.errors.map((error) => error.message);
     return res.status(400).json({ errors: messages });
   }
 
+  // `ErrorHandler` son los errores que el propio código levanta a propósito, con
+  // un mensaje pensado para la persona que usa el portal ("Contraseña
+  // incorrecta.", "Recurso no autorizado."). El portal los muestra tal cual
+  // (`userForm.js` lee `error.response.data.error`), así que se conservan.
+  //
+  // `statusCode` puede venir indefinido si se construye con un objeto sin
+  // `code`; sin este respaldo, `res.status(undefined)` lanza.
   if (err instanceof ErrorHandler) {
-    return res.status(err.statusCode).json({ error: err.message });
+    return res.status(err.statusCode || 500).json({ error: err.message });
   }
 
+  // Los de Sequelize, en cambio, son internos: sus mensajes traen SQL, nombres
+  // de columna y a veces valores. Se responde con un texto genérico.
   if (err instanceof ConnectionError) {
-    return res.status(500).json({ error: err.message });
+    return res.status(503).json({ error: 'Servicio no disponible. Intenta nuevamente en unos minutos.' });
   }
 
   if (err instanceof DatabaseError) {
-    return res.status(400).json({ error: err.message });
+    return res.status(400).json({ error: 'La solicitud no es válida.' });
   }
 
-  return res.status(500).json({ error: err.message });
+  return res.status(500).json({ error: 'Ocurrió un error inesperado.' });
 };
 
-module.exports = errorHandler
+module.exports = errorHandler;

--- a/API/src/server.js
+++ b/API/src/server.js
@@ -10,17 +10,15 @@ const server = app.listen(PORT, () => {
     startSchedulers();
 });
 
-// Cierra conexiones keep-alive ociosas y acota la fase de recepción de
-// cabeceras. `headersTimeout` va por encima de `keepAliveTimeout` para evitar
-// la condición de carrera que Node documenta entre ambos.
-//
 // A propósito NO se fija `server.setTimeout`: acota la duración total del
 // manejador, y acá hay peticiones legítimamente largas. `POST /wellData` espera
 // hasta 12 s a la DGA, y `POST /repostAllReportsToDGA` reenvía lotes de a 3 en
 // paralelo, así que puede tardar minutos. Un tope de request cortaría envíos
 // reales al regulador.
-server.keepAliveTimeout = 65_000;
-server.headersTimeout = 66_000;
+//
+// Los timeouts de conexiones ociosas (`keepAliveTimeout`, `headersTimeout`) van
+// aparte, porque hay que contrastarlos con la configuración de Nginx antes de
+// aplicarlos.
 
 const registrarFatal = (tipo, error) => {
     console.error(JSON.stringify({

--- a/API/src/server.js
+++ b/API/src/server.js
@@ -3,7 +3,73 @@ const { startSchedulers } = require('./jobs/scheduler');
 
 const PORT = process.env.PORT || 3000;
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
+    // Este mensaje es la señal que el runbook de despliegue usa para confirmar
+    // que la aplicación recargó tras un `git pull`. No cambiar el texto.
     console.log(`Escuchando en el puerto ${PORT}`);
     startSchedulers();
 });
+
+// Cierra conexiones keep-alive ociosas y acota la fase de recepción de
+// cabeceras. `headersTimeout` va por encima de `keepAliveTimeout` para evitar
+// la condición de carrera que Node documenta entre ambos.
+//
+// A propósito NO se fija `server.setTimeout`: acota la duración total del
+// manejador, y acá hay peticiones legítimamente largas. `POST /wellData` espera
+// hasta 12 s a la DGA, y `POST /repostAllReportsToDGA` reenvía lotes de a 3 en
+// paralelo, así que puede tardar minutos. Un tope de request cortaría envíos
+// reales al regulador.
+server.keepAliveTimeout = 65_000;
+server.headersTimeout = 66_000;
+
+const registrarFatal = (tipo, error) => {
+    console.error(JSON.stringify({
+        level: 'fatal',
+        msg: tipo,
+        name: error instanceof Error ? error.name : undefined,
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        at: new Date().toISOString(),
+    }));
+};
+
+// Sin estos handlers, una excepción no capturada mata el proceso sin dejar más
+// rastro que el stack de Node. Fue lo que pasó el 4 de agosto de 2026: la API
+// quedó caída y nadie se enteró hasta que alguien intentó usarla.
+//
+// Se registra y se sale con código 1. Salir es lo correcto: tras una
+// `uncaughtException` el estado del proceso es indeterminado y seguir sirviendo
+// peticiones puede corromper datos.
+//
+// ⚠️ Con nodemon, `exit(1)` deja la aplicación caída igual: nodemon no termina,
+// se queda esperando cambios en archivos, así que Docker ve vivo el PID 1 y no
+// aplica su política de reinicio. Lo que se gana hoy es el registro, que antes
+// no existía. Para que además se levante sola hace falta el issue #71 (correr
+// con `node` en vez de nodemon) o pasarle `--exitcrash` a nodemon.
+process.on('uncaughtException', (error) => {
+    registrarFatal('uncaughtException', error);
+    process.exit(1);
+});
+
+// Desde Node 15 una rejection sin capturar ya termina el proceso, pero sin este
+// handler lo hace sin contexto propio. Registrarlo es la diferencia entre poder
+// diagnosticar el incidente y no poder.
+process.on('unhandledRejection', (reason) => {
+    registrarFatal('unhandledRejection', reason);
+    process.exit(1);
+});
+
+// Apagado ordenado: deja de aceptar conexiones nuevas y espera a que terminen
+// las peticiones en curso. Importa porque un `POST /wellData` en vuelo puede
+// estar transmitiendo al regulador.
+const apagar = (senal) => {
+    console.log(JSON.stringify({ level: 'info', msg: `${senal} recibido, cerrando` }));
+    server.close(() => process.exit(0));
+    // Si alguna conexión no cierra, no quedarse colgado para siempre.
+    setTimeout(() => process.exit(1), 10_000).unref();
+};
+
+process.on('SIGTERM', () => apagar('SIGTERM'));
+process.on('SIGINT', () => apagar('SIGINT'));
+
+module.exports = server;

--- a/API/tests/middlewares/error.test.js
+++ b/API/tests/middlewares/error.test.js
@@ -1,0 +1,121 @@
+// error.test.js
+//
+// Sin base de datos: se construyen los errores de Sequelize a mano.
+
+const { ValidationError, ValidationErrorItem, ConnectionError, DatabaseError } = require('sequelize');
+const errorHandler = require('../../src/middlewares/error.middleware');
+const ErrorHandler = require('../../src/utils/error.util');
+
+// Doble de `res` que registra lo que se responde.
+const hacerRes = (headersSent = false) => {
+  const res = {
+    headersSent,
+    statusCode: undefined,
+    cuerpo: undefined,
+    status(code) { this.statusCode = code; return this; },
+    json(body) { this.cuerpo = body; return this; },
+  };
+  return res;
+};
+
+const req = { method: 'POST', originalUrl: '/users/login' };
+
+let errorSpy;
+beforeEach(() => { errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); });
+afterEach(() => { errorSpy.mockRestore(); });
+
+describe('errorHandler', () => {
+  describe('respuesta ya enviada', () => {
+    it('delega en Express en vez de intentar un segundo envío', () => {
+      // Responder dos veces lanza ERR_HTTP_HEADERS_SENT, que sin handler de
+      // proceso mata la aplicación. Es lo que tumbó producción en agosto.
+      const res = hacerRes(true);
+      const next = jest.fn();
+
+      errorHandler(new Error('lo que sea'), req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.statusCode).toBeUndefined();
+      expect(res.cuerpo).toBeUndefined();
+    });
+  });
+
+  describe('errores propios: el mensaje se conserva', () => {
+    // El portal los muestra al usuario tal cual (`userForm.js` lee
+    // `error.response.data.error`), así que no se pueden genericar.
+    it('respeta el status y el mensaje de ErrorHandler', () => {
+      const res = hacerRes();
+      errorHandler(new ErrorHandler({ message: 'Contraseña incorrecta.', code: 400 }), req, res, jest.fn());
+
+      expect(res.statusCode).toBe(400);
+      expect(res.cuerpo).toEqual({ error: 'Contraseña incorrecta.' });
+    });
+
+    it('usa 500 si el ErrorHandler viene sin código', () => {
+      // `new ErrorHandler({ message })` deja `statusCode` indefinido, y
+      // `res.status(undefined)` lanza. Con el respaldo, responde 500.
+      const res = hacerRes();
+      errorHandler(new ErrorHandler({ message: 'sin código' }), req, res, jest.fn());
+
+      expect(res.statusCode).toBe(500);
+    });
+
+    it('devuelve la lista de mensajes de un ValidationError', () => {
+      const res = hacerRes();
+      const err = new ValidationError('falló', [
+        new ValidationErrorItem('El email ya existe'),
+      ]);
+
+      errorHandler(err, req, res, jest.fn());
+
+      expect(res.statusCode).toBe(400);
+      expect(res.cuerpo.errors).toContain('El email ya existe');
+    });
+  });
+
+  describe('errores internos: el mensaje NO se filtra', () => {
+    it('un DatabaseError responde genérico, sin SQL', () => {
+      const res = hacerRes();
+      const err = new DatabaseError(
+        Object.assign(new Error('invalid input syntax for type integer: "2abc"'), {
+          sql: 'SELECT * FROM "roles" WHERE "id" = \'2abc\';',
+        })
+      );
+
+      errorHandler(err, req, res, jest.fn());
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.stringify(res.cuerpo)).not.toMatch(/SELECT|roles|syntax/);
+    });
+
+    it('un ConnectionError responde 503 sin exponer el host', () => {
+      const res = hacerRes();
+      errorHandler(new ConnectionError(new Error('connect ECONNREFUSED 127.0.0.1:5432')), req, res, jest.fn());
+
+      expect(res.statusCode).toBe(503);
+      expect(JSON.stringify(res.cuerpo)).not.toMatch(/ECONNREFUSED|5432|127\.0\.0\.1/);
+    });
+
+    it('un error cualquiera responde 500 sin su mensaje', () => {
+      const res = hacerRes();
+      errorHandler(new Error('/usr/src/app/src/controllers/user.controller.js:409'), req, res, jest.fn());
+
+      expect(res.statusCode).toBe(500);
+      expect(JSON.stringify(res.cuerpo)).not.toMatch(/usr\/src\/app/);
+    });
+  });
+
+  describe('lo que se registra', () => {
+    it('loguea el error con la ruta, y nunca el body', () => {
+      const res = hacerRes();
+      const conBody = { ...req, body: { password: 'secreto-del-usuario' } };
+
+      errorHandler(new Error('falló algo'), conBody, res, jest.fn());
+
+      const registrado = errorSpy.mock.calls[0][0];
+      expect(registrado).toMatch(/falló algo/);
+      expect(registrado).toMatch(/\/users\/login/);
+      expect(registrado).not.toMatch(/secreto-del-usuario/);
+    });
+  });
+});

--- a/API/tests/server.test.js
+++ b/API/tests/server.test.js
@@ -1,0 +1,101 @@
+// server.test.js
+//
+// Levanta el servidor real en subprocesos: los handlers de proceso no se pueden
+// probar en el proceso de jest sin matarlo. No consulta la base —cargar los
+// modelos no abre conexión hasta la primera consulta— y bloquea axios antes de
+// cargar nada, para que ningún camino pueda transmitir a la DGA.
+
+const { spawn } = require('child_process');
+const path = require('path');
+
+const API = path.join(__dirname, '..');
+
+// Cada subproceso usa un puerto propio para poder correr en paralelo.
+let siguientePuerto = 3960;
+
+const levantar = (inyectar = 'void 0;', senal = null) =>
+  new Promise((resolve) => {
+    const puerto = siguientePuerto++;
+    const guion = `
+      process.env.PORT = '${puerto}';
+      const axios = require(${JSON.stringify(path.join(API, 'node_modules/axios'))});
+      const bloquear = async () => { throw new Error('BLOQUEADO'); };
+      axios.post = bloquear; axios.get = bloquear;
+      const crear = axios.create.bind(axios);
+      axios.create = (c) => { const x = crear(c); x.post = bloquear; return x; };
+      require(${JSON.stringify(path.join(API, 'src/server.js'))});
+      setTimeout(() => { ${inyectar} }, 300);
+      setTimeout(() => process.exit(42), 5000);
+    `;
+    const hijo = spawn(process.execPath, ['-e', guion], { cwd: API });
+
+    let salida = '';
+    hijo.stdout.on('data', (d) => { salida += d; });
+    hijo.stderr.on('data', (d) => { salida += d; });
+    if (senal) setTimeout(() => hijo.kill(senal), 500);
+    hijo.on('exit', (code) => resolve({ code, salida }));
+  });
+
+// Extrae la línea de log estructurado del tipo pedido.
+const registroDe = (salida, tipo) => {
+  const linea = salida.split('\n').find((l) => l.includes(`"${tipo}"`));
+  try { return JSON.parse(linea); } catch { return null; }
+};
+
+jest.setTimeout(30_000);
+
+describe('server', () => {
+  it('arranca conservando la señal que usa el runbook y los schedulers', async () => {
+    // El runbook de despliegue usa "Escuchando en el puerto N" para confirmar
+    // que la aplicación recargó tras el git pull. Cambiar ese texto rompe la
+    // verificación documentada.
+    const { salida } = await levantar();
+
+    expect(salida).toMatch(/Escuchando en el puerto \d+/);
+    expect(salida).toMatch(/\[scheduler\]/);
+  });
+
+  describe('excepción no capturada', () => {
+    it('registra el detalle y sale con código 1', async () => {
+      // Antes el proceso moría sin más rastro que el stack de Node, y con
+      // nodemon quedaba caído sin que nadie se enterara.
+      const { code, salida } = await levantar("setTimeout(() => { throw new Error('boom'); }, 0);");
+
+      expect(code).toBe(1);
+      const registro = registroDe(salida, 'uncaughtException');
+      expect(registro).toMatchObject({ level: 'fatal', message: 'boom' });
+      expect(registro.stack).toBeTruthy();
+      expect(registro.at).toBeTruthy();
+    });
+  });
+
+  describe('rejection no capturada', () => {
+    it('registra el motivo y sale con código 1', async () => {
+      const { code, salida } = await levantar("Promise.reject(new Error('promesa rota'));");
+
+      expect(code).toBe(1);
+      expect(registroDe(salida, 'unhandledRejection')).toMatchObject({
+        level: 'fatal',
+        message: 'promesa rota',
+      });
+    });
+
+    it('también registra un rechazo que no es un Error', async () => {
+      const { code, salida } = await levantar("Promise.reject('texto suelto');");
+
+      expect(code).toBe(1);
+      expect(registroDe(salida, 'unhandledRejection').message).toBe('texto suelto');
+    });
+  });
+
+  describe('apagado ordenado', () => {
+    // Importa porque un POST /wellData en vuelo puede estar transmitiendo al
+    // regulador: se deja de aceptar conexiones y se espera a las que están.
+    it.each(['SIGTERM', 'SIGINT'])('%s cierra con código 0 y lo deja registrado', async (senal) => {
+      const { code, salida } = await levantar('void 0;', senal);
+
+      expect(code).toBe(0);
+      expect(salida).toMatch(new RegExp(`${senal} recibido`));
+    });
+  });
+});

--- a/API/tests/server.test.js
+++ b/API/tests/server.test.js
@@ -10,12 +10,12 @@ const path = require('path');
 
 const API = path.join(__dirname, '..');
 
-// Cada subproceso usa un puerto propio para poder correr en paralelo.
-let siguientePuerto = 3960;
-
+// Puerto 0 = el sistema asigna uno libre. Con puertos fijos, dos corridas
+// simultáneas chocan con EADDRINUSE, que además ahora es una excepción no
+// capturada y tumbaría el subproceso.
 const levantar = (inyectar = 'void 0;', senal = null) =>
   new Promise((resolve) => {
-    const puerto = siguientePuerto++;
+    const puerto = 0;
     const guion = `
       process.env.PORT = '${puerto}';
       const axios = require(${JSON.stringify(path.join(API, 'node_modules/axios'))});
@@ -29,11 +29,17 @@ const levantar = (inyectar = 'void 0;', senal = null) =>
     `;
     const hijo = spawn(process.execPath, ['-e', guion], { cwd: API });
 
-    let salida = '';
-    hijo.stdout.on('data', (d) => { salida += d; });
-    hijo.stderr.on('data', (d) => { salida += d; });
+    // Se acumulan por separado: los logs fatales van a stderr y el arranque a
+    // stdout, y concatenarlos permite que una línea se intercale dentro de otra
+    // y rompa el JSON.parse.
+    let stdout = '';
+    let stderr = '';
+    hijo.stdout.on('data', (d) => { stdout += d; });
+    hijo.stderr.on('data', (d) => { stderr += d; });
     if (senal) setTimeout(() => hijo.kill(senal), 500);
-    hijo.on('exit', (code) => resolve({ code, salida }));
+    // Se espera a 'close' y no a 'exit': en 'exit' los pipes pueden no estar
+    // drenados todavía y la salida llegaría truncada.
+    hijo.on('close', (code) => resolve({ code, stdout, stderr, salida: stdout + stderr }));
   });
 
 // Extrae la línea de log estructurado del tipo pedido.
@@ -49,20 +55,20 @@ describe('server', () => {
     // El runbook de despliegue usa "Escuchando en el puerto N" para confirmar
     // que la aplicación recargó tras el git pull. Cambiar ese texto rompe la
     // verificación documentada.
-    const { salida } = await levantar();
+    const { stdout } = await levantar();
 
-    expect(salida).toMatch(/Escuchando en el puerto \d+/);
-    expect(salida).toMatch(/\[scheduler\]/);
+    expect(stdout).toMatch(/Escuchando en el puerto \d+/);
+    expect(stdout).toMatch(/\[scheduler\]/);
   });
 
   describe('excepción no capturada', () => {
     it('registra el detalle y sale con código 1', async () => {
       // Antes el proceso moría sin más rastro que el stack de Node, y con
       // nodemon quedaba caído sin que nadie se enterara.
-      const { code, salida } = await levantar("setTimeout(() => { throw new Error('boom'); }, 0);");
+      const { code, stderr } = await levantar("setTimeout(() => { throw new Error('boom'); }, 0);");
 
       expect(code).toBe(1);
-      const registro = registroDe(salida, 'uncaughtException');
+      const registro = registroDe(stderr, 'uncaughtException');
       expect(registro).toMatchObject({ level: 'fatal', message: 'boom' });
       expect(registro.stack).toBeTruthy();
       expect(registro.at).toBeTruthy();
@@ -71,20 +77,20 @@ describe('server', () => {
 
   describe('rejection no capturada', () => {
     it('registra el motivo y sale con código 1', async () => {
-      const { code, salida } = await levantar("Promise.reject(new Error('promesa rota'));");
+      const { code, stderr } = await levantar("Promise.reject(new Error('promesa rota'));");
 
       expect(code).toBe(1);
-      expect(registroDe(salida, 'unhandledRejection')).toMatchObject({
+      expect(registroDe(stderr, 'unhandledRejection')).toMatchObject({
         level: 'fatal',
         message: 'promesa rota',
       });
     });
 
     it('también registra un rechazo que no es un Error', async () => {
-      const { code, salida } = await levantar("Promise.reject('texto suelto');");
+      const { code, stderr } = await levantar("Promise.reject('texto suelto');");
 
       expect(code).toBe(1);
-      expect(registroDe(salida, 'unhandledRejection').message).toBe('texto suelto');
+      expect(registroDe(stderr, 'unhandledRejection').message).toBe('texto suelto');
     });
   });
 
@@ -92,10 +98,10 @@ describe('server', () => {
     // Importa porque un POST /wellData en vuelo puede estar transmitiendo al
     // regulador: se deja de aceptar conexiones y se espera a las que están.
     it.each(['SIGTERM', 'SIGINT'])('%s cierra con código 0 y lo deja registrado', async (senal) => {
-      const { code, salida } = await levantar('void 0;', senal);
+      const { code, stdout } = await levantar('void 0;', senal);
 
       expect(code).toBe(0);
-      expect(salida).toMatch(new RegExp(`${senal} recibido`));
+      expect(stdout).toMatch(new RegExp(`${senal} recibido`));
     });
   });
 });


### PR DESCRIPTION
## Issues relacionados

Cierra **#64** y **#65**. Sin ticket de Jira asociado.

Van juntos porque son las dos mitades de la misma red de seguridad: uno evita que el proceso muera en silencio, el otro evita que el propio manejador de errores lo mate.

Sólo backend. **Sí cambia lo que el portal recibe en los errores inesperados** — ver "Impacto en el portal".

## Descripción del problema: la aplicación se moría sin dejar rastro

`server.js` era un `app.listen` pelado, sin `uncaughtException`, sin `unhandledRejection` y sin manejo de señales. Cualquier excepción no capturada mataba el proceso sin más registro que el stack de Node.

Eso ocurrió el 4 de agosto de 2026 y la API quedó caída hasta que alguien la reinició a mano. La única señal fue que alguien intentó usar el sistema.

Y el propio middleware de errores no comprobaba `res.headersSent`, así que si un controlador ya había respondido y después caía al handler, intentaba un segundo envío.

> **Corrección:** una primera versión de esta descripción decía que eso «es literalmente el patrón que tumbó producción». La revisión lo desmintió montando el caso contra Express real: con el middleware viejo el proceso **sobrevive**, porque Express envuelve los error-middlewares en `Layer.handle_error` y atrapa el `ERR_HTTP_HEADERS_SENT` síncrono. El crash de agosto fue dentro de un handler async, y eso ya lo cerró el PR #82. El guard sigue siendo correcto y deja los logs limpios, pero no es el arreglo del incidente.

A eso se suma que los 500 devolvían `err.message` crudo. Los errores de Sequelize traen SQL, nombres de columna y a veces valores: con la base caída, `POST /users/login` —que es anónimo— respondía `connect ECONNREFUSED 127.0.0.1:5432`.

## Solución propuesta

**En `server.js`**: handlers de `uncaughtException` y `unhandledRejection` que registran un JSON con nombre, mensaje, stack y hora, y salen con código 1. Más apagado ordenado con `SIGTERM`/`SIGINT`, que importa porque un `POST /wellData` en vuelo puede estar transmitiendo al regulador.

Sobre la ventana de apagado: el código espera a que cierren las conexiones y fuerza la salida a los 10 s. **En producción esa espera es de 3 s**, porque el `docker-compose.yml` fija `stop_grace_period: 3s` para todos los contenedores, así que Docker manda SIGKILL antes. No es una regresión —hasta ahora SIGTERM mataba al instante, sin ventana ninguna— pero conviene saber que el número real es 3 y no 10. Subirlo es un cambio de compose, no de código.

**Los timeouts de conexiones ociosas se sacaron de este PR.** `keepAliveTimeout` y `headersTimeout` eran las dos únicas líneas que dependen de cómo esté configurado Nginx, y esa comprobación hay que hacerla en la instancia. Van en **#85**, apilado sobre éste, para no bloquear el resto. Todo lo que queda acá es independiente de Nginx.

**En el middleware de errores**: guard de `res.headersSent` que delega en Express para que cierre el socket sin un segundo envío, log estructurado sin el `req.body`, y mensajes genéricos para los errores internos.

**Y en los controladores que esquivaban el middleware.** Endurecerlo no bastaba: sólo lo alcanza el código que llama a `next(error)`, y varios controladores responden desde su propio `catch` con `error.message`. Verificado contra una base muerta, `GET /well` y `POST /wellData` —las dos públicas y sin token— devolvían `connect ECONNREFUSED 127.0.0.1:5432`. O sea que el PR arreglaba el ejemplo del issue y dejaba filtrando justo los dos endpoints anónimos. Ahora delegan.

### Tres decisiones que conviene revisar

**No se fija `server.setTimeout`.** El cambio original del PR #54 lo ponía en 15 s. Acota la duración total del manejador, y acá hay peticiones legítimamente largas: `POST /wellData` espera hasta 12 s a la DGA, y `POST /repostAllReportsToDGA` reenvía lotes de a 3 en paralelo, así que puede tardar minutos. Un tope de request cortaría envíos reales al regulador. Sí se fijan `keepAliveTimeout` y `headersTimeout`, que sólo afectan conexiones ociosas y la fase de cabeceras.

**Se conserva el texto `Escuchando en el puerto N`.** El runbook de despliegue lo usa como señal de que la aplicación recargó tras el `git pull`. El cambio original lo reemplazaba por JSON, lo que habría roto esa verificación en silencio. Hay un test que lo fija.

**Se conserva `startSchedulers()`.** El commit del PR #54 cerrado no lo incluye, porque es de abril y anterior a los schedulers. Traerlo tal cual habría revertido el monitoreo, que es justo lo que llevó a cerrar aquel PR.

## Impacto en el portal: cambian los mensajes de error inesperado

Los errores que el código levanta a propósito (`ErrorHandler`) **conservan su mensaje**, porque el portal los muestra al usuario tal cual — `userForm.js:103` lee `error.response.data.error`. "Contraseña incorrecta." y "Recurso no autorizado." siguen llegando igual. Los `ValidationError` de Sequelize también conservan su lista, que el portal lee en `data.errors`.

Lo que cambia son los inesperados:

| antes | ahora |
|---|---|
| `500 {"error":"connect ECONNREFUSED 127.0.0.1:5432"}` | `503 {"error":"Servicio no disponible. Intenta nuevamente en unos minutos."}` |
| `400 {"error":"invalid input syntax for type integer: \"2.9\""}` | `400 {"error":"La solicitud no es válida."}` |
| `500 {"error":"/usr/src/app/src/controllers/..."}` | `500 {"error":"Ocurrió un error inesperado."}` |

Los formularios del portal caen a `error.message` de axios cuando no encuentran `data.errors`, así que siguen mostrando algo. Y para la persona que usa el sistema, "Servicio no disponible" es más útil que un `ECONNREFUSED`.

## Screenshots

No aplica: no hay cambios visuales en el backend.

## Cómo probar

**Tests incorporados**

14 casos nuevos: 8 para el middleware y 6 para el arranque y los handlers de proceso. Estos últimos levantan el servidor real en subprocesos, porque los handlers no se pueden probar dentro del proceso de jest sin matarlo.

```
npx jest tests/server.test.js tests/middlewares/ tests/utils/
Test Suites: 5 passed  ·  Tests: 66 passed, 66 total
```

Verificado en subprocesos reales:

```
ARRANQUE
  ✓ conserva el mensaje que usa el runbook      ✓ sigue arrancando los schedulers
EXCEPCIÓN NO CAPTURADA
  ✓ sale con código 1    ✓ registra JSON nivel fatal, con mensaje y stack
REJECTION NO CAPTURADA
  ✓ sale con código 1    ✓ registra el motivo, sea Error o no
APAGADO ORDENADO
  ✓ SIGTERM y SIGINT salen con código 0 y lo dejan registrado
```

Los dos e2e de los PRs anteriores (permisos y `validate-params`) se volvieron a correr enteros y siguen en verde.

**Después de desplegar**

En `sudo docker logs api -f`, confirmar que aparece `Escuchando en el puerto 3000` y las líneas `[scheduler]`. Y que siguen entrando los `POST /wellData` con 200, que es la señal de que la ingesta está viva.

## Cambios tras la revisión

Una revisión independiente confirmó lo importante: **los handlers no pueden causar pérdida de datos**. Analizó la secuencia del envío a la DGA y no existe ninguna ventana en la que un `exit(1)` deje un reporte marcado como enviado sin haberlo transmitido. El peor caso es un envío duplicado, que es la dirección segura frente al regulador. También verificó que ningún flujo del portal pierde un mensaje accionable, que los 23 códigos de `errorcodes.util.js` tienen `code`, y que ninguna señal del runbook se rompe.

Pero encontró que **la fuga seguía abierta en los dos endpoints anónimos**, más tres cosas que se corrigen acá:

- Los controladores que responden desde su propio `catch` esquivan el middleware (detallado arriba).
- El guard de `NODE_ENV === 'production'` era **código muerto**: `config/config.js` no tiene bloque `production`, así que con ese valor la aplicación ni siquiera arranca. Creíamos estar ocultando el stack sin ocultarlo. Ahora cuelga de `LOG_STACK`, que es explícito, y por defecto se registra: sin Sentry ni agregador, `docker logs` es el único diagnóstico que hay.
- `getUserInfoById` lanzaba `ErrorHandler(roleNotFound)` y **`roleNotFound` no existe** en `errorcodes.util` ni está importado: era un `ReferenceError`, no el 404 que pretendía. Y leía `client.userId` sin comprobar que el cliente existiera. Los dos arreglados.
- Los tests de `server.js` tenían flakiness latente: resolvían en `'exit'`, donde los pipes pueden no estar drenados, y concatenaban `stdout` con `stderr`, lo que permite que una línea se intercale y rompa el `JSON.parse`. Ahora esperan `'close'` y separan los flujos. Además usan puerto 0 en vez de puertos fijos, porque con puertos fijos dos corridas simultáneas chocan con `EADDRINUSE` — que ahora es una excepción no capturada y tumbaría el subproceso.

Verificado con la base apuntando a un puerto muerto:

```
GET  /well        → 503 {"error":"Servicio no disponible..."}   ✓ sin detalle interno
GET  /well/1      → 401 {"error":"Token no encontrado."}        ✓
POST /wellData    → 503 {"error":"Servicio no disponible..."}   ✓
POST /users/login → 503 {"error":"Servicio no disponible..."}   ✓
```

## Este PR ya no depende de Nginx

Se separó a **#85** lo único que sí dependía. Los handlers de proceso, el middleware de errores y la fuga de internals en los endpoints públicos no tocan la capa de proxy, así que este PR se puede mergear sin verificar nada en la instancia.

## ⚠️ Esto todavía no hace que se levante sola

Con **nodemon**, `exit(1)` deja la aplicación caída igual: nodemon no termina, se queda esperando cambios en archivos, así que Docker ve vivo el PID 1 y no aplica su política de reinicio.

Lo que se gana hoy es **el registro**, que antes no existía: cuando vuelva a pasar, habrá una línea `"level":"fatal"` con el stack en vez de un contenedor `Up` sirviendo 502 sin explicación.

Para que además se reinicie sola hay dos caminos, y el segundo es casi gratis:

- **#71** — correr con `node` en vez de nodemon. Es el arreglo de fondo, y necesita ventana de despliegue.
- **`nodemon --exitcrash`** — hace que nodemon termine cuando la aplicación muere, y ahí sí entra el `restart: unless-stopped` del compose. Ojo: el script `dev` se usa también en local, donde ese comportamiento estorba, así que habría que separar el script de producción.

Queda fuera de este PR a propósito: cambia cómo arranca el contenedor y merece su propia ventana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
