### PR TITLE
perf: acota las conexiones keep-alive ociosas (requiere confirmar Nginx)

### DIFF
--- a/API/src/server.js
+++ b/API/src/server.js
@@ -15,10 +15,18 @@ const server = app.listen(PORT, () => {
 // hasta 12 s a la DGA, y `POST /repostAllReportsToDGA` reenvía lotes de a 3 en
 // paralelo, así que puede tardar minutos. Un tope de request cortaría envíos
 // reales al regulador.
+
+// Cierra las conexiones keep-alive ociosas y acota la fase de recepción de
+// cabeceras. `headersTimeout` va por encima de `keepAliveTimeout` para evitar
+// la condición de carrera que Node documenta entre ambos.
 //
-// Los timeouts de conexiones ociosas (`keepAliveTimeout`, `headersTimeout`) van
-// aparte, porque hay que contrastarlos con la configuración de Nginx antes de
-// aplicarlos.
+// ⚠️ El valor tiene que ser MAYOR que el timeout con el que Nginx mantiene sus
+// conexiones hacia el backend. Si fuera menor, Nginx podría reutilizar una
+// conexión que Node acaba de cerrar y el usuario recibiría un 502 intermitente.
+// Sólo aplica si el sitio define un `upstream` con la directiva `keepalive`;
+// sin ella, Nginx abre una conexión por petición y esto es indiferente.
+server.keepAliveTimeout = 65_000;
+server.headersTimeout = 66_000;
 
 const registrarFatal = (tipo, error) => {
     console.error(JSON.stringify({


### PR DESCRIPTION
## Issues relacionados

Sin issue ni ticket de Jira. Sale de la revisión del **#84**, del que se separó para no bloquearlo.

**Apilado sobre #84.** La base de este PR es su rama; cuando el #84 se mergee, GitHub reapunta esta a `master` automáticamente y el diff queda en las dos líneas.

## ⚠️ No mergear sin confirmar la configuración de Nginx

Es el motivo entero de que este PR exista por separado.

`server.keepAliveTimeout` tiene que ser **mayor** que el timeout con el que Nginx mantiene sus conexiones hacia el backend. Si fuera menor, Nginx podría reutilizar una conexión que Node acaba de cerrar, y el usuario recibiría un **502 intermitente** — de los más difíciles de diagnosticar, porque aparece en una petición de cada tantas y no deja error en el backend.

### Cómo confirmarlo

```bash
ssh -i ~/proyectos_personales/credenciales/wellproject.pem ubuntu@3.137.51.212
sudo nginx -T 2>/dev/null | grep -B2 -A8 'upstream'
sudo nginx -T 2>/dev/null | grep -nE 'keepalive|proxy_http_version'
```

**Si no aparece ningún `upstream ... { keepalive N; }`** → Nginx abre una conexión por petición, el pool no existe y esto es indiferente. Se puede mergear tal cual.

**Si aparece** → comparar su `keepalive_timeout` (por defecto 60 s) con los 65 s de este PR. Mientras el del backend sea mayor, no hay riesgo. Si estuviera configurado por encima de 65 s, hay que subir el valor de `server.js`.

## Qué entrega

```js
server.keepAliveTimeout = 65_000;
server.headersTimeout = 66_000;
```

Node deja las conexiones keep-alive abiertas 5 s por defecto, lo que detrás de un proxy produce más handshakes de los necesarios. Subirlo a 65 s las reutiliza mejor.

`headersTimeout` va deliberadamente por encima de `keepAliveTimeout`: Node documenta una condición de carrera entre ambos si se fijan al revés.

### Lo que NO hace, a propósito

No fija `server.setTimeout`, que es lo que traía el cambio original del PR #54 cerrado. Ése acota la duración total del manejador, y acá hay peticiones legítimamente largas: `POST /wellData` espera hasta 12 s a la DGA, y `POST /repostAllReportsToDGA` reenvía lotes de a 3 en paralelo, así que puede tardar minutos. Un tope de request cortaría envíos reales al regulador.

## Screenshots

No aplica.

## Cómo probar

Los 66 tests siguen pasando (`npx jest tests/server.test.js tests/middlewares/ tests/utils/`), pero conviene ser honesto: **ninguno cubre esto**. Son valores de configuración cuyo efecto sólo se observa contra un proxy real.

La verificación de verdad es la de arriba, en la instancia, y después del despliegue vigilar que no aparezcan 502 esporádicos en el portal durante los primeros minutos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
