### PR TITLE
fix: impide mover un pozo de cuenta o sabotear su reintento desde el PUT

### DIFF
--- a/API/models/client.js
+++ b/API/models/client.js
@@ -2,6 +2,7 @@
 
 const ErrorHandler = require('../src/utils/error.util');
 const { badPasswordValidation } = require('../src/utils/errorcodes.util');
+const soloCampos = require('../src/utils/only-fields.util');
 
 const {
   Model
@@ -42,11 +43,6 @@ module.exports = (sequelize, DataTypes) => {
   // texto plano y dejaría la cuenta sin poder iniciar sesión.
   const CAMPOS_EDITABLES_USER = ['name', 'email', 'roleId', 'isActived'];
   const CAMPOS_EDITABLES_PERSON = ['fullName', 'personalEmail', 'phoneNumber', 'location'];
-
-  const soloCampos = (data, permitidos) =>
-    Object.fromEntries(
-      Object.entries(data).filter(([campo]) => permitidos.includes(campo))
-    );
 
   client.prototype.updateDetails = async function (user, person, data) {
     if (data.encrypted_password) {

--- a/API/models/company.js
+++ b/API/models/company.js
@@ -2,6 +2,7 @@
 
 const ErrorHandler = require('../src/utils/error.util');
 const { badPasswordValidation } = require('../src/utils/errorcodes.util');
+const soloCampos = require('../src/utils/only-fields.util');
 
 const {
   Model
@@ -73,11 +74,6 @@ module.exports = (sequelize, DataTypes) => {
   const CAMPOS_EDITABLES_COMPANY = [
     'companyLogo', 'companyRut', 'phoneNumber', 'recoveryEmail', 'location', 'distributorId',
   ];
-
-  const soloCampos = (data, permitidos) =>
-    Object.fromEntries(
-      Object.entries(data).filter(([campo]) => permitidos.includes(campo))
-    );
 
   company.prototype.updateDetails = async function (user, data) {
     if (data.encrypted_password) {

--- a/API/models/distributor.js
+++ b/API/models/distributor.js
@@ -4,6 +4,7 @@ const ErrorHandler = require("../src/utils/error.util");
 const { badPasswordValidation } = require("../src/utils/errorcodes.util");
 
 const { Model } = require("sequelize");
+const soloCampos = require('../src/utils/only-fields.util');
 module.exports = (sequelize, DataTypes) => {
   class distributor extends Model {
     /**
@@ -79,11 +80,6 @@ module.exports = (sequelize, DataTypes) => {
   const CAMPOS_EDITABLES_DISTRIBUTOR = [
     "distributorLogo", "distributorRut", "phoneNumber", "recoveryEmail", "location",
   ];
-
-  const soloCampos = (data, permitidos) =>
-    Object.fromEntries(
-      Object.entries(data).filter(([campo]) => permitidos.includes(campo))
-    );
 
   distributor.prototype.updateDetails = async function (user, data) {
     if (data.encrypted_password) {

--- a/API/src/controllers/client.controller.js
+++ b/API/src/controllers/client.controller.js
@@ -2,6 +2,21 @@ const db = require('../../models');
 const ErrorHandler = require('../utils/error.util');
 const checkPermissionsForClientResources = require('../utils/check-permissions');
 const assertCanChangeRole = require('../utils/assert-role-change');
+const soloCampos = require('../utils/only-fields.util');
+
+// Lo único que se puede escribir en un pozo desde el portal.
+//
+// Fuera quedan `clientId`, que decidiría a qué cuenta pertenece el pozo, y
+// `editStatusDate`, que fija el controlador al activar o desactivar y que
+// `fetchUnsentReports` usa para decidir qué reportes reintentar: escribirla a
+// futuro deja los envíos fallidos de ese pozo sin reintentar jamás.
+//
+// Las credenciales DGA sí entran: el formulario del pozo las edita
+// (`wellForm.js` registra `rutEmpresa`, `rutUsuario` y `password`), y quien
+// llega hasta acá ya pasó la validación de pertenencia.
+const CAMPOS_EDITABLES_WELL = [
+  'name', 'location', 'code', 'isActived', 'rutEmpresa', 'rutUsuario', 'password',
+];
 const {
   unauthorized,
   userHasNoClientAssociated,
@@ -230,7 +245,7 @@ const editClientWell = async (req, res, next) => {
     const willBeActive = req.body.isActived !== undefined ? req.body.isActived : wasActive;
     const activationChanged = wasActive !== willBeActive;
 
-    await well.update(req.body);
+    await well.update(soloCampos(req.body, CAMPOS_EDITABLES_WELL));
 
     // Log activation/deactivation
     if (activationChanged) {
@@ -391,7 +406,10 @@ const createClientWell = async (req, res, next) => {
       throw new ErrorHandler(unauthorized);
     }
 
-    const well = await Well.create({ ...req.body, clientId: client.id });
+    const well = await Well.create({
+      ...soloCampos(req.body, CAMPOS_EDITABLES_WELL),
+      clientId: client.id,
+    });
 
     // Create activity log
     try {

--- a/API/src/controllers/well.controller.js
+++ b/API/src/controllers/well.controller.js
@@ -37,6 +37,11 @@ const getAllWells = async (req, res, next) => {
 // Fuera queda `editStatusDate`, que fija el controlador de activación y sobre la
 // que pivotea `fetchUnsentReports`: escribirla a futuro deja los envíos
 // fallidos de ese pozo sin reintentar jamás.
+//
+// Ojo, esto no cierra el problema entero: crear un pozo con `isActived: true`
+// lo deja activo y con `editStatusDate` en null, y `fetchUnsentReports` exige
+// que no sea null, así que sus envíos fallidos tampoco se reintentan. Es el
+// issue #69, y viene igual desde `/clients/:id/wells/create`.
 const CAMPOS_CREABLES_WELL = [
   'name', 'location', 'code', 'isActived', 'rutEmpresa', 'rutUsuario', 'password',
 ];

--- a/API/src/controllers/well.controller.js
+++ b/API/src/controllers/well.controller.js
@@ -1,7 +1,8 @@
 //well.controller.js
 const checkPermissionsForClientResources = require('../utils/check-permissions');
 const ErrorHandler = require('../utils/error.util');
-const { unauthorized } = require('../utils/errorcodes.util');
+const { unauthorized, clientNotFound } = require('../utils/errorcodes.util');
+const soloCampos = require('../utils/only-fields.util');
 const activityLogService = require('../services/activityLog.service');
 const db = require('../../models')
 
@@ -32,10 +33,35 @@ const getAllWells = async (req, res, next) => {
   }
 }
 
+// Los mismos campos que acepta la creación desde `/clients/:id/wells/create`.
+// Fuera queda `editStatusDate`, que fija el controlador de activación y sobre la
+// que pivotea `fetchUnsentReports`: escribirla a futuro deja los envíos
+// fallidos de ese pozo sin reintentar jamás.
+const CAMPOS_CREABLES_WELL = [
+  'name', 'location', 'code', 'isActived', 'rutEmpresa', 'rutUsuario', 'password',
+];
+
 const createWell = async (req, res, next) => {
-  try { 
-    const well = await Well.create(req.body)
-    res.json({created: well})
+  try {
+    // El `clientId` viene del body y decide de quién es el pozo, así que hay
+    // que comprobar que quien llama pueda operar sobre ese cliente. Sin esto,
+    // cualquier usuario autenticado podía crear un pozo sobre la cuenta de otro
+    // —y fijarle `editStatusDate`—, que es la misma vía que cierra el #81 en
+    // `/clients/:id/wells/create`, por otra puerta.
+    const client = await Client.findByPk(req.body.clientId);
+    if (!client) {
+      throw new ErrorHandler(clientNotFound);
+    }
+
+    if (!await checkPermissionsForClientResources(req.user, client)) {
+      throw new ErrorHandler(unauthorized);
+    }
+
+    const well = await Well.create({
+      ...soloCampos(req.body, CAMPOS_CREABLES_WELL),
+      clientId: client.id,
+    });
+    res.json({ created: well })
   } catch (error) {
     next(error);
   }

--- a/API/src/utils/only-fields.util.js
+++ b/API/src/utils/only-fields.util.js
@@ -1,0 +1,15 @@
+// Se queda sólo con los campos permitidos de un objeto.
+//
+// Existe porque `validate-params` no es un whitelist: comprueba los campos que
+// declara y deja pasar intactos los que no. Así que cualquier `update(req.body)`
+// o `create(req.body)` escribe cualquier columna del modelo, esté declarada o
+// no. La lista de permitidos es lo que convierte eso en un filtro real.
+//
+// Se define en un solo lugar a propósito: había tres copias literales de esta
+// función en los modelos, y una cuarta a punto de nacer en los pozos.
+const soloCampos = (data, permitidos) =>
+  Object.fromEntries(
+    Object.entries(data || {}).filter(([campo]) => permitidos.includes(campo))
+  );
+
+module.exports = soloCampos;

--- a/API/tests/utils/only-fields.test.js
+++ b/API/tests/utils/only-fields.test.js
@@ -1,0 +1,41 @@
+// only-fields.test.js
+
+const soloCampos = require('../../src/utils/only-fields.util');
+
+describe('soloCampos', () => {
+  it('deja pasar lo permitido y descarta el resto', () => {
+    const body = { name: 'Pozo', location: 'Renca', clientId: 1, id: 99 };
+
+    expect(soloCampos(body, ['name', 'location'])).toEqual({ name: 'Pozo', location: 'Renca' });
+  });
+
+  it('no inventa campos que el body no trae', () => {
+    // Importa: si devolviera las claves ausentes como `undefined`, un `update`
+    // las escribiría como NULL y borraría datos existentes.
+    expect(soloCampos({ name: 'Pozo' }, ['name', 'location', 'code'])).toEqual({ name: 'Pozo' });
+  });
+
+  it('conserva los valores falsy, que son legítimos', () => {
+    // `isActived: false` y una ubicación vacía tienen que poder guardarse.
+    expect(soloCampos({ isActived: false, location: '' }, ['isActived', 'location']))
+      .toEqual({ isActived: false, location: '' });
+  });
+
+  it('descarta claves de prototipo', () => {
+    const body = JSON.parse('{"name":"Pozo","__proto__":{"clientId":1},"constructor":"x"}');
+
+    const resultado = soloCampos(body, ['name']);
+
+    expect(resultado).toEqual({ name: 'Pozo' });
+    expect({}.clientId).toBeUndefined();
+  });
+
+  it('tolera un body ausente', () => {
+    expect(soloCampos(undefined, ['name'])).toEqual({});
+    expect(soloCampos(null, ['name'])).toEqual({});
+  });
+
+  it('con la lista vacía no deja pasar nada', () => {
+    expect(soloCampos({ name: 'Pozo' }, [])).toEqual({});
+  });
+});


### PR DESCRIPTION
Cierra **#81**. Ver el comentario del issue: el título está mal, editar las credenciales del propio pozo es la funcionalidad del portal, no el bug.

## El problema

`editClientWell` aplicaba el body crudo con `well.update(req.body)`, y `validate-params` no filtra. Verificado ejecutando como cliente normal sobre su propio pozo:

```
PUT /clients/3/wells/ABC123/edit {clientId: 1, editStatusDate: '2030-01-01'}
→ 200, clientId = 1 (era 3), editStatusDate reescrito
```

- **`clientId`** permite regalar un pozo a otra cuenta, sorteando la pertenencia que construyó el #77.
- **`editStatusDate`** lo usa `fetchUnsentReports` para decidir qué reintentar. A futuro deja los envíos fallidos de ese pozo sin reintentar jamás, en silencio.

## La solución

Allowlist en la edición y en la creación. Las credenciales DGA se mantienen editables porque el formulario del pozo las manda en cada edición. De paso se unifica `soloCampos`, que estaba copiado literal en los tres modelos.

## Verificación

72 tests en verde, más end-to-end contra la base local: la inyección de `clientId` y `editStatusDate` se bloquea, y editar nombre, ubicación y credenciales sigue funcionando. Los e2e de los PRs anteriores siguen pasando.

⚠️ **Sin revisar por agente**, a diferencia de los anteriores: la sesión se cortó por la caída de producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)