### PR TITLE
fix: acota fetchUnsentReports a 3 días y lo pagina (causa raíz de la caída)

### DIFF
--- a/API/src/controllers/wellData.controller.js
+++ b/API/src/controllers/wellData.controller.js
@@ -7,6 +7,7 @@ const Client = db.client;
 const processAndPostData = require("../services/wellData/handleSendData.service");
 const ErrorHandler = require("../utils/error.util");
 const checkPermissionsForClientResources = require("../utils/check-permissions");
+const getPaginationParameters = require("../utils/query-params.util");
 const moment = require("moment-timezone");
 const { bulkCreateWellDataIsNotArray, unauthorized } = require("../utils/errorcodes.util");
 
@@ -330,22 +331,63 @@ const repostToDGA = async (req, res, next) => {
   }
 };
 
+// Ventana de reintento. Un reporte que lleva más de tres días sin enviarse ya
+// no se reintenta: la DGA lo rechazaría por duplicado o por antigüedad, y
+// arrastrar la cola histórica es lo que hizo crecer esta consulta sin techo.
+// Decidido con el cliente el 11 de agosto de 2026: la cola anterior se da por
+// perdida.
+const DIAS_DE_VENTANA = 3;
+
+// Tope de reportes por respuesta. Sin él, esta consulta materializaba en memoria
+// los 57.977 reportes pendientes: el 10 de agosto de 2026 Node pidió 11,5 GB en
+// una instancia de 957 MB, el OOM killer lo mató y la máquina quedó inaccesible
+// 14 horas. Ver el postmortem en `errores/06-caida-2026-08-10...`.
+const TAMANO_PAGINA_POR_DEFECTO = 100;
+const TAMANO_PAGINA_MAXIMO = 500;
+
 const fetchUnsentReports = async (req, res, next) => {
   try {
-    // Se obtienen todos los reportes no mandados de pozos activos
-    console.log("Buscando reportes no enviados");
+    const ahora = moment().tz("America/Santiago");
+    // `createdAt <= ahora - 2h` da margen a que el envío automático del hook
+    // `afterCreate` haya tenido su oportunidad antes de reintentar.
+    const hasta = ahora.clone().subtract(2, "hours").toDate();
+    const desde = ahora.clone().subtract(DIAS_DE_VENTANA, "days").toDate();
 
-    // Obtener fecha actual en zona horaria correcta (Chile) y restar 2 horas
-    const twoHoursAgo = moment().tz("America/Santiago").subtract(2, "hours").toDate();
+    // El tamaño se acota siempre, incluso si quien llama pide más: el objetivo
+    // es que ninguna petición pueda volver a tumbar la instancia. Se acota por
+    // arriba y por abajo: un `size` o un `page` negativos generan un `LIMIT` o
+    // un `OFFSET` negativos, que Postgres rechaza.
+    // Se usa `Number` y no `parseInt` por el mismo motivo que en
+    // `assert-role-change.js`: `parseInt` lee un prefijo y descarta el resto,
+    // así que `'1.5'` daría 1 y `'5x'` daría 5. Acá eso convertiría una entrada
+    // inválida en una página de tamaño 1 en vez de caer al valor por defecto.
+    const enRango = (valor, porDefecto, minimo, maximo) => {
+      if (valor === undefined || valor === null || valor === '') {
+        return porDefecto;
+      }
+      const n = Number(valor);
+      if (!Number.isInteger(n) || n < minimo) {
+        return porDefecto;
+      }
+      return Math.min(n, maximo);
+    };
 
-    const unsentReports = await WellData.findAll({
+    const { limit, offset } = getPaginationParameters({
+      size: enRango(req.query.size, TAMANO_PAGINA_POR_DEFECTO, 1, TAMANO_PAGINA_MAXIMO),
+      page: enRango(req.query.page, 0, 0, Number.MAX_SAFE_INTEGER),
+    });
+
+    const { count, rows: unsentReports } = await WellData.findAndCountAll({
       where: {
         sent: false,
         createdAt: {
-          // solo incluir reportes creados después de la última edición del pozo
+          // Sólo reportes creados después de la última edición del pozo.
           [db.Op.gte]: db.Sequelize.col("well.editStatusDate"),
-          [db.Op.lte]: twoHoursAgo, // createdAt debe ser <= ahora - 2h
+          [db.Op.lte]: hasta,
         },
+        // La ventana va en su propia condición porque `createdAt` ya tiene un
+        // `gte` contra la columna del pozo y un mismo objeto no admite dos.
+        [db.Op.and]: [{ createdAt: { [db.Op.gte]: desde } }],
       },
       include: [
         {
@@ -363,22 +405,44 @@ const fetchUnsentReports = async (req, res, next) => {
           },
         },
       ],
+      // Sin un orden estable, paginar es incorrecto: entre una página y la
+      // siguiente el motor puede devolver las filas en otro orden y quedarían
+      // reportes repetidos y otros nunca entregados. Se ordena por antigüedad,
+      // que además es el orden en que conviene reintentar.
+      order: [["createdAt", "ASC"], ["id", "ASC"]],
+      limit,
+      offset,
     });
 
-    // Si no hay reportes no enviados, se envía un 404
+    // Si no hay reportes no enviados, se envía un 404. El SENDER depende de
+    // esto: trata cualquier respuesta no exitosa como "no hay nada que hacer".
     if (unsentReports.length === 0) {
-      console.log("NO HAY REPORTES NO ENVIADOS!!!!!!!!!!!!!!!!");
       return res.status(404).send({
         message: "No hay reportes no enviados",
       });
     }
 
-    console.log("Reportes encontrados: ", unsentReports.length);
-    let formattedReports = { reports: {} };
+    console.log(
+      `[sender] entregando ${unsentReports.length} de ${count} reportes pendientes ` +
+      `de los últimos ${DIAS_DE_VENTANA} días (offset ${offset})`
+    );
+
+    // Se conserva la forma `{ reports: { id: reporte } }` porque es lo que el
+    // SENDER consume (`json_response['reports'].values`). La paginación se
+    // agrega como clave aparte para no romper ese contrato.
+    const formattedReports = { reports: {} };
     unsentReports.forEach((report) => {
-      formattedReports["reports"][report.id] = report;
+      formattedReports.reports[report.id] = report;
     });
-    res.json(formattedReports).status(200);
+    formattedReports.pagination = {
+      totalItems: count,
+      totalPages: Math.ceil(count / limit),
+      currentPage: Math.floor(offset / limit),
+      pageSize: limit,
+      windowDays: DIAS_DE_VENTANA,
+    };
+
+    res.status(200).json(formattedReports);
   } catch (error) {
     next(error);
   }

--- a/API/tests/controllers/fetch-unsent-reports.test.js
+++ b/API/tests/controllers/fetch-unsent-reports.test.js
@@ -1,0 +1,182 @@
+// fetch-unsent-reports.test.js
+//
+// Sin base de datos: se mockea el modelo y se comprueban las opciones con las
+// que se consulta. Lo que importa acá es que la consulta no pueda volver a
+// crecer sin techo, y eso se ve en las opciones, no en las filas.
+//
+// El 10 de agosto de 2026 esta consulta materializó los 57.977 reportes
+// pendientes: Node pidió 11,5 GB en una instancia de 957 MB, el OOM killer lo
+// mató y la máquina quedó inaccesible 14 horas.
+
+const mockFindAndCountAll = jest.fn();
+
+jest.mock('../../models', () => {
+  const { Op, Sequelize } = jest.requireActual('sequelize');
+  return {
+    wellData: { findAndCountAll: (...a) => mockFindAndCountAll(...a) },
+    well: {},
+    client: {},
+    Op,
+    Sequelize,
+  };
+});
+jest.mock('../../src/services/wellData/handleSendData.service', () => jest.fn());
+
+const { fetchUnsentReports } = require('../../src/controllers/wellData.controller');
+
+const hacerRes = () => ({
+  statusCode: undefined,
+  cuerpo: undefined,
+  status(c) { this.statusCode = c; return this; },
+  json(b) { this.cuerpo = b; return this; },
+  send(b) { this.cuerpo = b; return this; },
+});
+
+// Genera `n` reportes con la forma mínima que el controlador usa.
+const filas = (n) =>
+  Array.from({ length: n }, (_, i) => ({ id: i + 1, code: 'ABC123', createdAt: new Date() }));
+
+const correr = async (query = {}) => {
+  const res = hacerRes();
+  const next = jest.fn();
+  await fetchUnsentReports({ query }, res, next);
+  return { res, next, opciones: mockFindAndCountAll.mock.calls[0]?.[0] };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  mockFindAndCountAll.mockResolvedValue({ count: 250, rows: filas(100) });
+});
+
+afterEach(() => { console.log.mockRestore(); });
+
+describe('fetchUnsentReports', () => {
+  describe('la consulta no puede crecer sin techo', () => {
+    it('siempre pide un límite', async () => {
+      const { opciones } = await correr();
+      expect(opciones.limit).toBe(100);
+    });
+
+    it('acota el tamaño aunque quien llama pida más', async () => {
+      const { opciones } = await correr({ size: '100000' });
+      expect(opciones.limit).toBe(500);
+    });
+
+    it('cae al valor por defecto con un tamaño inválido', async () => {
+      for (const size of ['0', 'abc', '-5', '', '1.5', undefined]) {
+        jest.clearAllMocks();
+        mockFindAndCountAll.mockResolvedValue({ count: 1, rows: filas(1) });
+        const { opciones } = await correr({ size });
+        expect(opciones.limit).toBe(100);
+      }
+    });
+
+    it('respeta un tamaño razonable', async () => {
+      const { opciones } = await correr({ size: '250' });
+      expect(opciones.limit).toBe(250);
+    });
+  });
+
+  describe('la ventana de tres días', () => {
+    it('acota por fecha de creación además de por `sent`', async () => {
+      const { opciones } = await correr();
+
+      // La ventana viaja en un `Op.and` propio porque `createdAt` ya lleva un
+      // `gte` contra la columna del pozo y un mismo objeto no admite dos.
+      const condiciones = opciones.where[Object.getOwnPropertySymbols(opciones.where)
+        .find((s) => s.toString().includes('and'))];
+      const desde = condiciones[0].createdAt[
+        Object.getOwnPropertySymbols(condiciones[0].createdAt)[0]
+      ];
+
+      const diasAtras = (Date.now() - desde.getTime()) / (1000 * 60 * 60 * 24);
+      expect(diasAtras).toBeGreaterThan(2.9);
+      expect(diasAtras).toBeLessThan(3.1);
+    });
+
+    it('sigue pidiendo sólo los no enviados', async () => {
+      const { opciones } = await correr();
+      expect(opciones.where.sent).toBe(false);
+    });
+  });
+
+  describe('el orden hace que paginar sea correcto', () => {
+    it('ordena de forma estable y determinista', async () => {
+      // Sin `ORDER BY`, el motor puede devolver las filas en distinto orden
+      // entre una página y la siguiente: habría reportes repetidos y otros
+      // que no se entregarían nunca. Se desempata por `id` porque `createdAt`
+      // puede repetirse.
+      const { opciones } = await correr();
+      expect(opciones.order).toEqual([['createdAt', 'ASC'], ['id', 'ASC']]);
+    });
+
+    it('desplaza el offset según la página pedida', async () => {
+      const { opciones } = await correr({ page: '2' });
+      expect(opciones.offset).toBe(200);
+    });
+
+    it('nunca genera un LIMIT ni un OFFSET negativos', async () => {
+      // Postgres rechaza ambos con un error de base, que el usuario vería como
+      // un 400 sin explicación.
+      for (const query of [{ page: '-3' }, { size: '-5' }, { page: '-1', size: '-1' }]) {
+        jest.clearAllMocks();
+        mockFindAndCountAll.mockResolvedValue({ count: 1, rows: filas(1) });
+        const { opciones } = await correr(query);
+        expect(opciones.limit).toBeGreaterThan(0);
+        expect(opciones.offset).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe('el contrato con el SENDER', () => {
+    it('conserva la forma { reports: { id: reporte } }', async () => {
+      // El SENDER hace `json_response['reports'].values`. Cambiar esta forma
+      // lo rompe en silencio.
+      const { res } = await correr();
+
+      expect(res.statusCode).toBe(200);
+      expect(res.cuerpo.reports['1']).toMatchObject({ id: 1, code: 'ABC123' });
+    });
+
+    it('agrega la paginación sin tocar `reports`', async () => {
+      const { res } = await correr();
+
+      expect(res.cuerpo.pagination).toMatchObject({
+        totalItems: 250,
+        totalPages: 3,
+        currentPage: 0,
+        pageSize: 100,
+        windowDays: 3,
+      });
+    });
+
+    it('sigue devolviendo 404 cuando no hay nada', async () => {
+      // El SENDER trata cualquier respuesta no exitosa como "nada que hacer".
+      mockFindAndCountAll.mockResolvedValue({ count: 0, rows: [] });
+      const { res } = await correr();
+
+      expect(res.statusCode).toBe(404);
+      expect(res.cuerpo.message).toMatch(/No hay reportes/);
+    });
+
+    it('no expone las credenciales DGA del pozo', async () => {
+      const { opciones } = await correr();
+      const includeWell = opciones.include[0];
+
+      expect(includeWell.attributes.exclude).toEqual(
+        expect.arrayContaining(['password', 'rutEmpresa', 'rutUsuario'])
+      );
+    });
+  });
+
+  describe('errores', () => {
+    it('delega en el middleware en vez de responder el detalle interno', async () => {
+      mockFindAndCountAll.mockRejectedValue(new Error('connect ECONNREFUSED'));
+      const { res, next } = await correr();
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.statusCode).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Cierra **#63**. Es la **causa raíz de la caída del 10 de agosto**: ver el postmortem en `errores/06-caida-2026-08-10...`.

## El problema

La consulta traía todos los reportes con `sent: false`, sin ventana ni límite. El 10 de agosto eso fueron **57.977 reportes**: Node pidió 11,5 GB de memoria virtual en una instancia de 957 MB, el OOM killer lo mató, y como la máquina no tenía swap entró en *livelock* y quedó inaccesible 14 horas.

## Los dos cambios

**Ventana de 3 días.** Un reporte con más de tres días sin enviarse ya no se reintenta. La cola histórica se da por perdida — decidido con el cliente.

**Paginación con tope.** 100 por página por defecto, máximo 500, y el tope se aplica aunque quien llame pida más. Ninguna petición puede volver a materializar la tabla entera.

## Detalles que importan

**`ORDER BY createdAt, id`.** Sin orden estable, paginar es incorrecto: entre una página y la siguiente el motor puede devolver las filas en otro orden, y quedarían reportes repetidos y otros nunca entregados. Se ordena del más antiguo al más nuevo, que además es el orden en que conviene reintentar.

**El contrato con el SENDER no cambia.** Se conserva `{ reports: { id: reporte } }` —el SENDER hace `json_response['reports'].values`— y el 404 cuando no hay nada, que trata como "nada que hacer". La paginación va en una clave aparte.

**Los parámetros se acotan por arriba y por abajo.** Un `size` o un `page` negativos generaban `LIMIT` y `OFFSET` negativos, que Postgres rechaza. Y se usa `Number` en vez de `parseInt`, por el mismo motivo que en `assert-role-change`: `parseInt` lee un prefijo, así que `size=1.5` daba una página de tamaño 1 en vez de caer al valor por defecto.

## Verificación

80 tests en verde (14 nuevos). Más end-to-end contra la base local, sembrando 250 reportes dentro de la ventana y 40 fuera:

```
VENTANA         ✓ el total excluye los de 5 días atrás (250, no 290)
                ✓ la página trae el tope (100), no todo
PAGINACIÓN      ✓ las tres páginas no se solapan ni dejan huecos (250 únicos)
                ✓ el corte entre páginas respeta el orden por fecha
EL TOPE         ✓ pedir size=100000 se acota a 500
                ✓ size inválido o negativo cae al valor por defecto
CONTRATO        ✓ la forma { reports: { id } } se conserva
                ✓ los 7 campos que valida el SENDER siguen presentes
                ✓ el pozo sigue sin credenciales DGA
                ✓ una página vacía sigue devolviendo 404
```

La base local quedó intacta: 188 reportes, `editStatusDate` restaurado.

## Un detalle del contrato que conviene saber

La respuesta se ordena en SQL, pero la forma `{ id: reporte }` **reordena por id al serializar**: JavaScript devuelve las claves numéricas en orden ascendente, no en el de inserción. El orden *dentro* de una página no está garantizado; el que sí importa —y el que hace correcta la paginación— es el corte *entre* páginas, que sí sigue el `ORDER BY`.

## ⚠️ No encender el cron del SENDER todavía

Esto quita el riesgo de memoria, pero el SENDER tiene problemas propios que siguen abiertos: aborta el lote entero con el primer rechazo de la DGA, y su ritmo de 5 minutos por reporte le da un techo de 288/día contra ~1.100 que se acumulan. Ver el postmortem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)